### PR TITLE
[feat/#7] custom bottom sheet 구현

### DIFF
--- a/GG-iOS/GG-iOS/Global/Modifier/BorderModifier.swift
+++ b/GG-iOS/GG-iOS/Global/Modifier/BorderModifier.swift
@@ -1,0 +1,67 @@
+//
+//  BorderModifier.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 10/9/25.
+//
+
+import SwiftUI
+
+struct BorderModifier: ViewModifier {
+    private let borderType: BorderType
+    private let borderColor: Color
+    private let borderWidth: CGFloat
+    
+    init(borderType: BorderType, borderColor: Color, borderWidth: CGFloat = 1) {
+        self.borderType = borderType
+        self.borderColor = borderColor
+        self.borderWidth = borderWidth
+    }
+    
+    func body(content: Content) -> some View {
+        switch borderType {
+        case .roundedRectangle(let cornerRaius):
+            content.overlay(
+                RoundedRectangle(cornerRadius: cornerRaius)
+                    .stroke(borderColor, lineWidth: borderWidth)
+            )
+            
+        case .capsule:
+            content.overlay(
+                Capsule()
+                    .stroke(borderColor, lineWidth: borderWidth)
+            )
+            
+        case .circle:
+            content.overlay(
+                Circle()
+                    .stroke(borderColor, lineWidth: borderWidth)
+            )
+        }
+    }
+}
+
+extension BorderModifier {
+    enum BorderType {
+        case roundedRectangle(cornerRadius: CGFloat)
+        case capsule
+        case circle
+    }
+}
+
+extension View {
+    func addBorder(
+        _ borderType: BorderModifier.BorderType,
+        borderColor: Color,
+        borderWidth: CGFloat
+    ) -> some View {
+        self.modifier(
+            BorderModifier(
+                borderType: borderType,
+                borderColor: borderColor,
+                borderWidth: borderWidth
+            )
+        )
+    }
+}
+

--- a/GG-iOS/GG-iOS/Global/Modifier/CustomBottomSheetModifier.swift
+++ b/GG-iOS/GG-iOS/Global/Modifier/CustomBottomSheetModifier.swift
@@ -1,0 +1,143 @@
+//
+//  CustomBottomSheetModifier.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 10/8/25.
+//
+
+import SwiftUI
+
+struct CustomBottomSheetModifier<TopContent: View, SheetContent: View>: ViewModifier {
+    
+    // MARK: - Properties
+    
+    @State private var currentHeight: CGFloat = 400.adjustedHeight
+    @State private var topContentOpacity: Double = 1.0
+    
+    private let defaultHeight: CGFloat = 400.adjustedHeight
+    private let minimumHeight: CGFloat = 100.adjustedHeight
+    private let maximumHeight: CGFloat = 692.adjustedHeight
+    
+    private let topContent: () -> TopContent
+    private let sheetContent: () -> SheetContent
+    
+    // MARK: - Initializer
+    
+    init(
+        @ViewBuilder topContent: @escaping () -> TopContent,
+        @ViewBuilder sheetContent: @escaping () -> SheetContent
+    ) {
+        self.topContent = topContent
+        self.sheetContent = sheetContent
+    }
+    
+    // MARK: - Body
+    
+    func body(content: Content) -> some View {
+        ZStack(alignment: .bottom) {
+            content
+            
+            ZStack(alignment: .top) {
+                sheet
+                    .frame(height: currentHeight)
+                
+                topContent()
+                    .opacity(topContentOpacity)
+                    .offset(y: -50.adjustedHeight)
+            }
+        }
+        .ignoresSafeArea(edges: .bottom)
+    }
+}
+
+// MARK: - Subviews
+
+extension CustomBottomSheetModifier {
+    private var indicator: some View {
+        ZStack(alignment: .center) {
+            Rectangle()
+                .foregroundStyle(.gray200)
+                .frame(width: 43.adjustedWidth, height: 3.adjustedHeight)
+                .capsuleClipped()
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 20.adjustedHeight)
+    }
+    
+    private var sheet: some View {
+        VStack(alignment: .center, spacing: 0){
+            indicator
+            
+            sheetContent()
+                .frame(maxWidth: .infinity)
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background(.gray0)
+        .cornerRadius(20, corners: [.topLeft, .topRight])
+        .shadow(color: .gray900.opacity(0.15), radius: 10, x: 0, y: 0)
+        .simultaneousGesture(dragGesture)
+    }
+}
+
+// MARK: - Functions
+
+extension CustomBottomSheetModifier {
+    private func updateTopContentOpacity() {
+        let fadeRange: CGFloat = 70.adjustedHeight
+        
+        if currentHeight <= maximumHeight - fadeRange {
+            topContentOpacity = 1.0
+        } else if currentHeight <= maximumHeight {
+            topContentOpacity = 1.0 - ((currentHeight - (maximumHeight - fadeRange)) / fadeRange)
+        } else {
+            topContentOpacity = 0.0
+        }
+    }
+}
+
+// MARK: - Gestures
+
+extension CustomBottomSheetModifier {
+    private var dragGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                let newHeight = currentHeight - value.translation.height
+                let clampedHeight = min(max(newHeight, minimumHeight), maximumHeight)
+                currentHeight = clampedHeight
+                
+                updateTopContentOpacity()
+            }
+            .onEnded { value in
+                let newHeight = currentHeight - value.translation.height
+                let midPoint = (defaultHeight + maximumHeight) / 2
+                
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    if newHeight <= defaultHeight - 200.adjustedHeight {
+                        currentHeight = minimumHeight
+                    } else if newHeight > midPoint {
+                        currentHeight = maximumHeight
+                    } else {
+                        currentHeight = defaultHeight
+                    }
+                    
+                    updateTopContentOpacity()
+                }
+            }
+    }
+}
+
+// MARK: - Modifier
+
+extension View {
+    func customBottomSheet<TopContent: View, SheetContent: View>(
+        @ViewBuilder topContent: @escaping () -> TopContent,
+        @ViewBuilder sheetContent: @escaping () -> SheetContent
+    ) -> some View {
+        self.modifier(
+            CustomBottomSheetModifier(
+                topContent: topContent,
+                sheetContent: sheetContent
+            )
+        )
+    }
+}

--- a/GG-iOS/GG-iOS/Global/Util/RoundedCorner.swift
+++ b/GG-iOS/GG-iOS/Global/Util/RoundedCorner.swift
@@ -1,0 +1,47 @@
+//
+//  RoundedCorner.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 10/8/25.
+//
+
+import SwiftUI
+
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+    
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(
+            roundedRect: rect,
+            byRoundingCorners: corners,
+            cornerRadii: CGSize(
+                width: radius,
+                height: radius
+            )
+        )
+        
+        return Path(path.cgPath)
+    }
+}
+
+extension View {
+    /// 지정된 뷰에 둥근 모서리를 적용합니다.
+    /// - Parameters:
+    ///   - radius: 적용할 둥근 모서리의 반지름 값입니다.
+    ///   - corners: 둥글게 만들 모서리를 지정합니다. (예: .allCorners, [.bottomLeft, .bottomRight])
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape(RoundedCorner(radius: radius, corners: corners))
+    }
+    
+    /// 뷰 전체를 캡슐 형태로 자릅니다.
+    func capsuleClipped() -> some View {
+        self.clipShape(Capsule())
+    }
+    
+    /// 뷰 전체를 원형 형태로 자릅니다.
+    func circleClipped() -> some View {
+        self.clipShape(Circle())
+    }
+}
+

--- a/GG-iOS/GG-iOS/Global/Util/RoundedCorner.swift
+++ b/GG-iOS/GG-iOS/Global/Util/RoundedCorner.swift
@@ -5,6 +5,7 @@
 //  Created by 김승원 on 10/8/25.
 //
 
+import UIKit
 import SwiftUI
 
 struct RoundedCorner: Shape {

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -17,8 +17,18 @@ struct MapSheetView: View {
     // MARK: - Body
     
     var body: some View {
-        ZStack(alignment: .bottom) {
+        ZStack(alignment: .top) {
             map
+                .customBottomSheet(
+                    topContent: {
+                        topContent
+                    },
+                    sheetContent: {
+                        sheetContent
+                    }
+                )
+            
+            address
         }
     }
 }
@@ -40,6 +50,53 @@ extension MapSheetView {
         }
         .mapControlVisibility(.hidden)
         .mapStyle(.standard(pointsOfInterest: .excludingAll))
+    }
+    
+    private var address: some View {
+        ZStack(alignment: .leading) {
+            Rectangle()
+                .frame(width: 336.adjustedWidth, height: 48.adjustedHeight)
+                .foregroundStyle(.gray0)
+                .cornerRadius(10, corners: .allCorners)
+                .addBorder(.roundedRectangle(cornerRadius: 10), borderColor: .gray100, borderWidth: 1)
+            
+            Text("320 - 2 Hwajeong-dong Jangan-gu Suwon-si")
+                .applyGGFont(.body02)
+                .foregroundStyle(.textNatural)
+                .lineLimit(1)
+                .frame(width: 304.adjustedWidth)
+                .padding(.horizontal, 16.adjustedWidth)
+        }
+            
+    }
+    
+    private var topContent: some View {
+        Button {
+            
+        } label: {
+            ZStack(alignment: .center) {
+                Capsule()
+                    .frame(width: 121.adjustedWidth, height: 34.adjustedHeight)
+                    .foregroundStyle(.gray0)
+                    .addBorder(.capsule, borderColor: .gray200, borderWidth: 1)
+                
+                HStack(alignment: .center, spacing: 8.adjustedWidth) {
+                    Image(.showMapIcon)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 16.adjustedWidth, height: 16.adjustedHeight)
+                    
+                    Text("show map")
+                        .applyGGFont(.body02)
+                        .foregroundStyle(.textNatural)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+    
+    private var sheetContent: some View {
+        Text("sheet Content")
     }
 }
 


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 커스텀 바텀시트를 구현했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 16 pro   |
| :-------------: | :----------: | :----------: |
| A 기능 | <img src = "https://github.com/user-attachments/assets/c7dc21c0-bcf6-48de-93b0-6d0064596083" width ="250"> | <img src = "https://github.com/user-attachments/assets/0dd32632-9cd1-4340-8d1c-938703a1c489" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 커스텀 바텀시트 도입: 드래그로 높이 조절(최소/중간/최대), 애니메이션, 상단 콘텐츠 및 시트 콘텐츠 제공.
  - 테두리 유틸리티 추가: 둥근사각/캡슐/원형 형태, 색상 및 두께 설정 가능.
  - 모서리별 라운딩 및 캡슐·원형 클리핑 지원.

- UI 변경
  - 지도 화면에 커스텀 바텀시트 적용 및 상단의 “지도 보기” 버튼 추가.
  - 주소 오버레이 스타일 개선으로 가독성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->