### PR TITLE
[feat/#25] 바텀시트 지도 연동

### DIFF
--- a/GG-iOS/GG-iOS/Global/Enum/SheetState.swift
+++ b/GG-iOS/GG-iOS/Global/Enum/SheetState.swift
@@ -10,4 +10,16 @@ import Foundation
 enum SheetState: CaseIterable, Hashable {
     case list
     case detail
+    
+    static var defaultHeight: CGFloat {
+        return 400.adjustedHeight
+    }
+    
+    static var minimumHeight: CGFloat {
+        return 110.adjustedHeight
+    }
+    
+    static var maximumHeight: CGFloat {
+        return 692.adjustedHeight
+    }
 }

--- a/GG-iOS/GG-iOS/Global/Modifier/CustomBottomSheetModifier.swift
+++ b/GG-iOS/GG-iOS/Global/Modifier/CustomBottomSheetModifier.swift
@@ -11,12 +11,8 @@ struct CustomBottomSheetModifier<TopContent: View, SheetContent: View>: ViewModi
     
     // MARK: - Properties
     
-    @State private var currentHeight: CGFloat = 400.adjustedHeight
+    @Binding private var currentHeight: CGFloat
     @State private var topContentOpacity: Double = 1.0
-    
-    private let defaultHeight: CGFloat = 400.adjustedHeight
-    private let minimumHeight: CGFloat = 110.adjustedHeight
-    private let maximumHeight: CGFloat = 692.adjustedHeight
     
     private let topContent: () -> TopContent
     private let sheetContent: () -> SheetContent
@@ -24,9 +20,11 @@ struct CustomBottomSheetModifier<TopContent: View, SheetContent: View>: ViewModi
     // MARK: - Initializer
     
     init(
+        currentHeight: Binding<CGFloat>,
         @ViewBuilder topContent: @escaping () -> TopContent,
         @ViewBuilder sheetContent: @escaping () -> SheetContent
     ) {
+        self._currentHeight = currentHeight
         self.topContent = topContent
         self.sheetContent = sheetContent
     }
@@ -85,10 +83,10 @@ extension CustomBottomSheetModifier {
     private func updateTopContentOpacity() {
         let fadeRange: CGFloat = 70.adjustedHeight
         
-        if currentHeight <= maximumHeight - fadeRange {
+        if currentHeight <= SheetState.maximumHeight - fadeRange {
             topContentOpacity = 1.0
-        } else if currentHeight <= maximumHeight {
-            topContentOpacity = 1.0 - ((currentHeight - (maximumHeight - fadeRange)) / fadeRange)
+        } else if currentHeight <= SheetState.maximumHeight {
+            topContentOpacity = 1.0 - ((currentHeight - (SheetState.maximumHeight - fadeRange)) / fadeRange)
         } else {
             topContentOpacity = 0.0
         }
@@ -102,22 +100,22 @@ extension CustomBottomSheetModifier {
         DragGesture()
             .onChanged { value in
                 let newHeight = currentHeight - value.translation.height
-                let clampedHeight = min(max(newHeight, minimumHeight), maximumHeight)
+                let clampedHeight = min(max(newHeight, SheetState.minimumHeight), SheetState.maximumHeight)
                 currentHeight = clampedHeight
                 
                 updateTopContentOpacity()
             }
             .onEnded { value in
                 let newHeight = currentHeight - value.translation.height
-                let midPoint = (defaultHeight + maximumHeight) / 2
+                let midPoint = (SheetState.defaultHeight + SheetState.maximumHeight) / 2
                 
                 withAnimation(.easeInOut(duration: 0.3)) {
-                    if newHeight <= defaultHeight - 200.adjustedHeight {
-                        currentHeight = minimumHeight
+                    if newHeight <= SheetState.defaultHeight - 200.adjustedHeight {
+                        currentHeight = SheetState.minimumHeight
                     } else if newHeight > midPoint {
-                        currentHeight = maximumHeight
+                        currentHeight = SheetState.maximumHeight
                     } else {
-                        currentHeight = defaultHeight
+                        currentHeight = SheetState.defaultHeight
                     }
                     
                     updateTopContentOpacity()
@@ -130,11 +128,13 @@ extension CustomBottomSheetModifier {
 
 extension View {
     func customBottomSheet<TopContent: View, SheetContent: View>(
+        currentHeight: Binding<CGFloat>,
         @ViewBuilder topContent: @escaping () -> TopContent,
         @ViewBuilder sheetContent: @escaping () -> SheetContent
     ) -> some View {
         self.modifier(
             CustomBottomSheetModifier(
+                currentHeight: currentHeight,
                 topContent: topContent,
                 sheetContent: sheetContent
             )

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -82,7 +82,14 @@ extension MapSheetView {
                     }
                 }
             case .detail:
-                viewModel.dispatch(.switchSheetState(.detail))
+                
+                if viewModel.isBottomSheetMinimumHeight() {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        viewModel.dispatch(.showList)
+                    }
+                } else {
+                    viewModel.dispatch(.switchSheetState(.detail))
+                }
             }
         } label: {
             HStack(alignment: .center, spacing: 8.adjustedWidth) {

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -21,6 +21,7 @@ struct MapSheetView: View {
         ZStack(alignment: .top) {
             map
                 .customBottomSheet(
+                    currentHeight: $viewModel.bottomSheetHeight,
                     topContent: {
                         topContent
                     },
@@ -71,24 +72,36 @@ extension MapSheetView {
     
     private var topContent: some View {
         Button {
-            // TODO: - list일 때 sheet 내리기, detail일 때 list로 바꾸기
             switch viewModel.sheetState {
             case .list:
-                break
-                // TODO: - 바텀시트 내리기
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    if viewModel.isBottomSheetMinimumHeight() {
+                        viewModel.dispatch(.showList)
+                    } else {
+                        viewModel.dispatch(.showMap)
+                    }
+                }
             case .detail:
                 viewModel.dispatch(.switchSheetState(.detail))
             }
         } label: {
             HStack(alignment: .center, spacing: 8.adjustedWidth) {
-                Image(viewModel.sheetState == .list ? .showMapIcon : .showListIcon)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 16.adjusted, height: 16.adjusted)
+                Image(
+                    viewModel.isBottomSheetMinimumHeight()
+                    ? .showListIcon : viewModel.sheetState == .list
+                    ? .showMapIcon : .showListIcon
+                )
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 16.adjusted, height: 16.adjusted)
                 
-                Text(viewModel.sheetState == .list ? "Show map" : "Show list")
-                    .applyGGFont(.body02)
-                    .foregroundStyle(.textNatural)
+                Text(
+                    viewModel.isBottomSheetMinimumHeight()
+                    ? "Show list" : viewModel.sheetState == .list
+                    ? "Show map" : "Show list"
+                )
+                .applyGGFont(.body02)
+                .foregroundStyle(.textNatural)
             }
             .padding(.horizontal, 16.adjustedWidth)
             .padding(.vertical, 8.adjustedHeight)

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -15,6 +15,7 @@ final class MapSheetViewModel: ObservableObject {
     @Published var cameraPosition: MapCameraPosition
     @Published var sheetState: SheetState = .list
     @Published var mapPlaces: [MapPlace] = MapPlace.mockData
+    @Published var bottomSheetHeight: CGFloat = SheetState.defaultHeight
     
     // 임시 카메라 위치
     private let initialLocation = CLLocationCoordinate2D(latitude: 37.5598, longitude: 126.9770)
@@ -24,6 +25,8 @@ final class MapSheetViewModel: ObservableObject {
     // MARK: - Action
     
     enum Action {
+        case showMap
+        case showList
         case selectMarker(_ mapPlace: MapPlace)
         case selectPlace(_ mapPlace: MapPlace)
         case switchSheetState(_ sheetState: SheetState)
@@ -44,6 +47,12 @@ final class MapSheetViewModel: ObservableObject {
     
     func dispatch(_ action: Action) {
         switch action {
+        case .showMap:
+            bottomSheetHeight = SheetState.minimumHeight
+            
+        case .showList:
+            bottomSheetHeight = SheetState.defaultHeight
+            
         case .selectMarker(let mapPlace):
             selectMarker(mapPlace)
             setCameraPosition(coordinate: mapPlace.coordinate)
@@ -68,7 +77,7 @@ final class MapSheetViewModel: ObservableObject {
     }
 }
 
-// MARK: - Functions
+// MARK: - Private Functions
 
 private extension MapSheetViewModel {
     func selectMarker(_ selectedPlace: MapPlace) {
@@ -97,6 +106,14 @@ private extension MapSheetViewModel {
             
             cameraPosition = .region(MKCoordinateRegion(center: adjustedCenter, span: span))
         }
+    }
+}
+
+// MARK: - Functions
+
+extension MapSheetViewModel {
+    func isBottomSheetMinimumHeight() -> Bool {
+        return bottomSheetHeight == SheetState.minimumHeight
     }
 }
 

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -18,6 +18,7 @@ final class MapSheetViewModel: ObservableObject {
     @Published var bottomSheetHeight: CGFloat = SheetState.defaultHeight
     
     // 임시 카메라 위치
+    // TODO: - 바텀시트 내려감에 따라 지도 중심점 조정 필요
     private let initialLocation = CLLocationCoordinate2D(latitude: 37.5598, longitude: 126.9770)
     private let span = MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
     private let spanRate: Double = 0.45
@@ -58,6 +59,10 @@ final class MapSheetViewModel: ObservableObject {
             setCameraPosition(coordinate: mapPlace.coordinate)
             sheetState = .detail
             
+            withAnimation(.easeInOut(duration: 0.3)) {
+                bottomSheetHeight = SheetState.defaultHeight
+            }
+            
         case .selectPlace(let mapPlace):
             selectMarker(mapPlace)
             setCameraPosition(coordinate: mapPlace.coordinate)
@@ -66,7 +71,6 @@ final class MapSheetViewModel: ObservableObject {
         case .switchSheetState(let sheetState):
             switch sheetState {
             case .list:
-                // TODO: - 시트 내려가기 구현
                 break
                 
             case .detail:


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 바텀시트와 지도를 연동했습니다.

|    구현 내용    |   iPhone 13 mini   |   iPhone 17 pro   |
| :-------------: | :----------: | :----------: |
| 지도 시트 연동 | <img src = "https://github.com/user-attachments/assets/13625c16-0295-4067-bfa5-9f17a6575cd2" width ="250"> | <img src = "https://github.com/user-attachments/assets/75c7f1d2-a76d-46b5-bdd3-4b7f85e2c8fd" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #25 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 하단 시트의 높이 관리 방식을 개선하여 사용자 인터랙션 중 더 나은 높이 전환을 지원합니다.
  * 지도 시트의 상태 전환 시 높이 동기화를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->