### PR TITLE
[feat/#32] 장소 상세 API 연동

### DIFF
--- a/GG-iOS/GG-iOS/Global/Modifier/CustomSkeletonModifier.swift
+++ b/GG-iOS/GG-iOS/Global/Modifier/CustomSkeletonModifier.swift
@@ -13,11 +13,13 @@ struct CustomSkeletonModifier: ViewModifier {
     private let isLoading: Bool
     private let size: CGSize?
     private let radius: CGFloat
+    private let lines: Int
     
-    init(isLoading: Bool, size: CGSize?, radius: CGFloat) {
+    init(isLoading: Bool, size: CGSize?, radius: CGFloat, lines: Int) {
         self.isLoading = isLoading
         self.size = size
         self.radius = radius
+        self.lines = lines
     }
     
     func body(content: Content) -> some View {
@@ -25,7 +27,8 @@ struct CustomSkeletonModifier: ViewModifier {
             .skeleton(
                 with: isLoading,
                 size: size,
-                shape: .rounded(.radius(radius))
+                shape: .rounded(.radius(radius)),
+                lines: lines
             )
     }
 }
@@ -34,13 +37,15 @@ extension View {
     func customSkeleton(
         with isLoading: Bool,
         size: CGSize? = nil,
-        radius: CGFloat = 10
+        radius: CGFloat = 10,
+        lines: Int = 1
     ) -> some View {
         self.modifier(
             CustomSkeletonModifier(
                 isLoading: isLoading,
                 size: size,
-                radius: radius
+                radius: radius,
+                lines: lines
             )
         )
     }

--- a/GG-iOS/GG-iOS/Network/Base/BaseResponseBody.swift
+++ b/GG-iOS/GG-iOS/Network/Base/BaseResponseBody.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct BaseResponseBody<T: ResponseModelType>: ResponseModelType {
-    let code: String
+    let code: Int
     let message: String
     let data: T?
 }

--- a/GG-iOS/GG-iOS/Network/DTO/Response/PlaceDetailResponseDTO.swift
+++ b/GG-iOS/GG-iOS/Network/DTO/Response/PlaceDetailResponseDTO.swift
@@ -1,0 +1,18 @@
+//
+//  PlaceDetailResponseDTO.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/13/25.
+//
+
+import Foundation
+
+struct PlaceDetailResponseDTO: ResponseModelType {
+    let placeId: Int
+    let placeName: String
+    let address: String
+    let placeImages: [String]
+    let locationExplain: String
+    let price: String?
+    let inquiry: String
+}

--- a/GG-iOS/GG-iOS/Network/Service/PlaceDetailService.swift
+++ b/GG-iOS/GG-iOS/Network/Service/PlaceDetailService.swift
@@ -9,8 +9,8 @@ import Foundation
 
 final class PlaceDetailService: BaseService<PlaceDetailTargetType> { }
 
-extension PlaceDetailService {
-    func fetchPlaceDetail(placeId: Int) async throws -> BaseResponseBody<PlaceResponseDTO> {
+extension PlaceDetailService: PlaceDetailAPI {
+    func fetchPlaceDetail(placeId: Int) async throws -> BaseResponseBody<PlaceDetailResponseDTO> {
         return try await self.request(with: .fetchPlaceDetail(placeId: placeId))
     }
 }

--- a/GG-iOS/GG-iOS/Network/Service/PlaceDetailService.swift
+++ b/GG-iOS/GG-iOS/Network/Service/PlaceDetailService.swift
@@ -1,0 +1,16 @@
+//
+//  PlaceDetailService.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/13/25.
+//
+
+import Foundation
+
+final class PlaceDetailService: BaseService<PlaceDetailTargetType> { }
+
+extension PlaceDetailService {
+    func fetchPlaceDetail(placeId: Int) async throws -> BaseResponseBody<PlaceResponseDTO> {
+        return try await self.request(with: .fetchPlaceDetail(placeId: placeId))
+    }
+}

--- a/GG-iOS/GG-iOS/Network/TargerType/PlaceDetailTargetType.swift
+++ b/GG-iOS/GG-iOS/Network/TargerType/PlaceDetailTargetType.swift
@@ -1,0 +1,39 @@
+//
+//  PlaceDetailTargetType.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/13/25.
+//
+
+import Foundation
+
+import Moya
+
+enum PlaceDetailTargetType {
+    case fetchPlaceDetail(placeId: Int)
+}
+
+extension PlaceDetailTargetType: BaseTargetType {
+    var path: String {
+        switch self {
+        case .fetchPlaceDetail(let placeId):
+            return "/places/\(placeId)"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchPlaceDetail:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .fetchPlaceDetail:
+            return .requestPlain
+        }
+    }
+    
+    
+}

--- a/GG-iOS/GG-iOS/Network/TargerType/PlaceListTargetType.swift
+++ b/GG-iOS/GG-iOS/Network/TargerType/PlaceListTargetType.swift
@@ -23,7 +23,7 @@ extension PlaceListTargetType: BaseTargetType {
     
     var method: Moya.Method {
         switch self {
-        case .fetchPlaceList(let request):
+        case .fetchPlaceList:
             return .post
         }
     }

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/API/PlaceDetailAPI.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/API/PlaceDetailAPI.swift
@@ -1,0 +1,13 @@
+//
+//  PlaceDetailAPI.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/13/25.
+//
+
+import Foundation
+
+protocol PlaceDetailAPI {
+    /// 장소 상세 조회
+    func fetchPlaceDetail(placeId: Int) async throws -> BaseResponseBody<PlaceDetailResponseDTO>
+}

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/Model/MapPlace.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/Model/MapPlace.swift
@@ -33,7 +33,7 @@ extension MapPlace {
     static var mockData: [MapPlace] {
         [
             MapPlace(
-                placeId: 1,
+                placeId: 153,
                 placeName: "Seoul Station",
                 address: "175, Mallijae-ro, Jung-gu, Seoul, Republic of Korea",
                 imageUrlStrings: TempImageUrlString.threeImageUrlStrings(),

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/Model/PlaceDetail.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/Model/PlaceDetail.swift
@@ -17,6 +17,17 @@ struct PlaceDetail {
 }
 
 extension PlaceDetail {
+    init(from dto: PlaceDetailResponseDTO) {
+        self.placeName = dto.placeName
+        self.imageUrlStrings = dto.placeImages
+        self.address = dto.address
+        self.inquiry = dto.inquiry
+        self.price = dto.price
+        self.description = dto.locationExplain
+    }
+}
+
+extension PlaceDetail {
     static var mockData: PlaceDetail {
         return PlaceDetail(
             placeName: "Suwon Hwaseong1",

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/Model/PlaceDetail.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/Model/PlaceDetail.swift
@@ -1,0 +1,43 @@
+//
+//  PlaceDetail.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/13/25.
+//
+
+import Foundation
+
+struct PlaceDetail {
+    let placeName: String
+    let imageUrlStrings: [String]
+    let address: String
+    let inquiry: String
+    let price: String?
+    let description: String
+}
+
+extension PlaceDetail {
+    static var mockData: PlaceDetail {
+        return PlaceDetail(
+            placeName: "Suwon Hwaseong1",
+            imageUrlStrings: TempImageUrlString.threeImageUrlStrings(),
+            address: "320-2 Hwajeong-dong, Jangan-gu, Suwon-si",
+            inquiry: "www.nye020308.co.kr",
+            price: "Infant : free\nChildren : 3000\nAdult : 7000",
+            description: "The name was changed to Suwon Dohobu (護府) in the 17th year of King Jeongjo's reign (1793). It also refers to the fortress built here. In 1789, King Jeongjo moved the 園 of Crown Prince Jangheon (莊獻), his birth The name was changed to Suwon Dohobu (護府) in the 17th year of King Jeongjo's reign (1793). It also refers to the fortress built here. In 1789, King Jeongjo moved the 園 of Crown Prince Jangheon (莊獻), his birth."
+        )
+    }
+}
+
+extension PlaceDetail {
+    static var skeletonData: PlaceDetail {
+        return PlaceDetail(
+            placeName: "",
+            imageUrlStrings: ["1", "2", "3"],
+            address: "",
+            inquiry: "",
+            price: "",
+            description: ""
+        )
+    }
+}

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -34,6 +34,9 @@ struct MapSheetView: View {
             
             address
         }
+        .onAppear {
+//            viewModel.dispatch(.fetchPlaceList)
+        }
         .alert(isPresented: $viewModel.shouldShowErrorAlert) {
             Alert(
                 title: Text(viewModel.alertErrorMessage),

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -14,7 +14,8 @@ struct MapSheetView: View {
     
     @EnvironmentObject private var appCoordinator: AppCoordinator
     @StateObject private var viewModel = MapSheetViewModel(
-        placeListService: PlaceListService()
+        placeListService: PlaceListService(),
+        placeDetailService: PlaceDetailService()
     )
     
     // MARK: - Body

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceDetailView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceDetailView.swift
@@ -43,6 +43,7 @@ struct PlaceDetailView: View {
                 scrollSpacer
             }
         }
+        .disabled(viewModel.isPlaceDetailLoading)
     }
 }
 
@@ -56,7 +57,6 @@ extension PlaceDetailView {
         .padding(.horizontal, 20.adjustedWidth)
         .padding(.top, 20.adjustedHeight)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .disabled(viewModel.isPlaceDetailLoading)
     }
     
     private var details: some View {
@@ -77,7 +77,7 @@ extension PlaceDetailView {
             .lineLimit(1)
             .customSkeleton(
                 with: viewModel.isPlaceDetailLoading,
-                size: CGSize(width: 250.adjustedWidth, height: 31.adjustedHeight),
+                size: CGSize(width: 250.adjustedWidth, height: 33.adjustedHeight),
                 radius: 8
             )
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -90,7 +90,6 @@ extension PlaceDetailView {
                 .aspectRatio(contentMode: .fill)
                 .customSkeleton(with: viewModel.isPlaceDetailLoading)
                 .frame(width: 218.adjustedWidth, height: 168.adjustedHeight)
-                .background(.gray300)
                 .cornerRadius(10, corners: .allCorners)
             
             VStack(alignment: .center, spacing: 8.adjustedHeight) {
@@ -99,7 +98,6 @@ extension PlaceDetailView {
                     .aspectRatio(contentMode: .fill)
                     .customSkeleton(with: viewModel.isPlaceDetailLoading)
                     .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
-                    .background(.gray300)
                     .cornerRadius(10, corners: .allCorners)
                 
                 KFImage(URL(string: viewModel.placeDetail.imageUrlStrings[2]))
@@ -107,7 +105,6 @@ extension PlaceDetailView {
                     .aspectRatio(contentMode: .fill)
                     .customSkeleton(with: viewModel.isPlaceDetailLoading)
                     .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
-                    .background(.gray300)
                     .cornerRadius(10, corners: .allCorners)
             }
         }

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceDetailView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceDetailView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import Kingfisher
+
 struct PlaceDetailView: View {
     
     // MARK: - Properties
@@ -54,6 +56,7 @@ extension PlaceDetailView {
         .padding(.horizontal, 20.adjustedWidth)
         .padding(.top, 20.adjustedHeight)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .disabled(viewModel.isPlaceDetailLoading)
     }
     
     private var details: some View {
@@ -68,38 +71,46 @@ extension PlaceDetailView {
     }
     
     private var title: some View {
-        Text("Suwon Hwaseong")
+        Text(viewModel.placeDetail.placeName)
             .applyGGFont(.title02)
             .foregroundStyle(.textNatural)
-            .frame(maxWidth: .infinity, alignment: .leading)
             .lineLimit(1)
+            .customSkeleton(
+                with: viewModel.isPlaceDetailLoading,
+                size: CGSize(width: 250.adjustedWidth, height: 31.adjustedHeight),
+                radius: 8
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
     
     private var photos: some View {
         HStack(alignment: .center, spacing: 8.adjustedWidth) {
-            Image(.temp)
+            KFImage(URL(string: viewModel.placeDetail.imageUrlStrings[0]))
                 .resizable()
                 .aspectRatio(contentMode: .fill)
+                .customSkeleton(with: viewModel.isPlaceDetailLoading)
+                .frame(width: 218.adjustedWidth, height: 168.adjustedHeight)
                 .background(.gray300)
-                .frame(width: 218.adjustedWidth)
                 .cornerRadius(10, corners: .allCorners)
             
             VStack(alignment: .center, spacing: 8.adjustedHeight) {
-                Image(.temp)
+                KFImage(URL(string: viewModel.placeDetail.imageUrlStrings[1]))
                     .resizable()
                     .aspectRatio(contentMode: .fill)
+                    .customSkeleton(with: viewModel.isPlaceDetailLoading)
+                    .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
                     .background(.gray300)
                     .cornerRadius(10, corners: .allCorners)
                 
-                Image(.temp)
+                KFImage(URL(string: viewModel.placeDetail.imageUrlStrings[2]))
                     .resizable()
                     .aspectRatio(contentMode: .fill)
+                    .customSkeleton(with: viewModel.isPlaceDetailLoading)
+                    .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
                     .background(.gray300)
                     .cornerRadius(10, corners: .allCorners)
             }
         }
-        .frame(maxWidth: .infinity)
-        .frame(height: 168.adjustedHeight)
     }
     
     private var informations: some View {
@@ -107,23 +118,40 @@ extension PlaceDetailView {
             InformationWithIconRow(
                 InformationWithIcon(
                     informationType: .address,
-                    text: "320-2 Hwajeong-dong, Jangan-gu, Suwon-si"
+                    text: viewModel.placeDetail.address
                 )
+            )
+            .customSkeleton(
+                with: viewModel.isPlaceDetailLoading,
+                size: CGSize(width: 335.adjustedWidth, height: 16.adjustedHeight),
+                radius: 5
             )
             
             InformationWithIconRow(
                 InformationWithIcon(
                     informationType: .url,
-                    text: "www.nye020308.co.kr"
+                    text: viewModel.placeDetail.inquiry
                 )
+            )
+            .customSkeleton(
+                with: viewModel.isPlaceDetailLoading,
+                size: CGSize(width: 335.adjustedWidth, height: 16.adjustedHeight),
+                radius: 5
             )
             
-            InformationWithIconRow(
-                InformationWithIcon(
-                    informationType: .price,
-                    text: "Infant : free\nChildren : 3000\nAdult : 7000"
+            if let price = viewModel.placeDetail.price {
+                InformationWithIconRow(
+                    InformationWithIcon(
+                        informationType: .price,
+                        text: price
+                    )
                 )
-            )
+                .customSkeleton(
+                    with: viewModel.isPlaceDetailLoading,
+                    size: CGSize(width: 335.adjustedWidth, height: 16.adjustedHeight),
+                    radius: 5
+                )
+            }
         }
     }
     
@@ -140,10 +168,16 @@ extension PlaceDetailView {
                 .applyGGFont(.heading02)
                 .foregroundStyle(.textNatural)
             
-            Text("The name was changed to Suwon Dohobu (護府) in the 17th year of King Jeongjo's reign (1793). It also refers to the fortress built here. In 1789, King Jeongjo moved the 園 of Crown Prince Jangheon (莊獻), his birth The name was changed to Suwon Dohobu (護府) in the 17th year of King Jeongjo's reign (1793). It also refers to the fortress built here. In 1789, King Jeongjo moved the 園 of Crown Prince Jangheon (莊獻), his birth,")
+            Text(viewModel.placeDetail.description)
                 .applyGGFont(.body02)
                 .foregroundStyle(.textNormal)
                 .frame(width: 335.adjustedWidth, alignment: .leading)
+                .customSkeleton(
+                    with: viewModel.isPlaceDetailLoading,
+                    size: CGSize(width: 335.adjustedWidth, height: 55.adjustedHeight),
+                    radius: 4,
+                    lines: 3
+                )
         }
     }
     

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceListView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceListView.swift
@@ -45,12 +45,12 @@ extension PlaceListView {
     
     private var placeList: some View {
         VStack(alignment: .center, spacing: 20.adjustedHeight) {
-            ForEach(viewModel.isLoading ? MapPlace.skeletonData : viewModel.mapPlaces, id: \.id) { mapPlace in
+            ForEach(viewModel.isPlaceListLoading ? MapPlace.skeletonData : viewModel.mapPlaces, id: \.id) { mapPlace in
                 PlaceListRow(
                     title: mapPlace.placeName,
                     address: mapPlace.address,
                     imageUrlStrings: mapPlace.imageUrlStrings,
-                    isLoading: viewModel.isLoading,
+                    isLoading: viewModel.isPlaceListLoading,
                     onTap: {
                         viewModel.dispatch(.selectPlace(mapPlace))
                     }

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceListView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceListView.swift
@@ -30,9 +30,6 @@ struct PlaceListView: View {
             }
             .padding(.bottom, 40.adjustedHeight)
         }
-        .onAppear {
-            viewModel.dispatch(.fetchPlaceList)
-        }
     }
 }
 

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -20,7 +20,8 @@ final class MapSheetViewModel: ObservableObject {
     @Published var cameraPosition: MapCameraPosition
     @Published var sheetState: SheetState = .list
     @Published var bottomSheetHeight: CGFloat = SheetState.defaultHeight
-    @Published var mapPlaces: [MapPlace] = MapPlace.mockData // PlaceListAPI 고쳐지면 다시 빈배열
+    // TODO: - HomeAPI 수정되면 다시 빈배열로
+    @Published var mapPlaces: [MapPlace] = MapPlace.mockData
     @Published var placeDetail: PlaceDetail = PlaceDetail.skeletonData
     
     private let placeListService: PlaceListAPI
@@ -81,12 +82,12 @@ final class MapSheetViewModel: ObservableObject {
             fetchPlaceDetailTask?.cancel()
             fetchPlaceDetailTask = nil
             
-            placeDetail = PlaceDetail.skeletonData
             bottomSheetHeight = SheetState.defaultHeight
             
         case .selectMarker(let mapPlace):
             fetchPlaceDetailTask?.cancel()
             fetchPlaceDetailTask = Task {
+                // TODO: - 임시 placeId
                 await fetchPlaceDetail(placeId: 153)
             }
             
@@ -101,6 +102,7 @@ final class MapSheetViewModel: ObservableObject {
         case .selectPlace(let mapPlace):
             fetchPlaceDetailTask?.cancel()
             fetchPlaceDetailTask = Task {
+                // TODO: - 임시 placeId
                 await fetchPlaceDetail(placeId: 153)
             }
             
@@ -118,6 +120,7 @@ final class MapSheetViewModel: ObservableObject {
                 fetchPlaceDetailTask = nil
                 
                 deSelectMarker()
+                placeDetail = PlaceDetail.skeletonData
                 self.sheetState = .list
             }
             
@@ -219,13 +222,16 @@ private extension MapSheetViewModel {
                 return
             }
             
+            try Task.checkCancellation()
+            
             self.alertErrorMessage = ""
             self.isPlaceDetailLoading = false
             self.shouldShowErrorAlert = false
             self.placeDetail = PlaceDetail(from: data)
             
         } catch is CancellationError {
-            self.isPlaceDetailLoading = false
+            self.isPlaceDetailLoading = true
+            self.placeDetail = PlaceDetail.skeletonData
             
         } catch let error as NetworkError {
             self.alertErrorMessage = error.alertMessage

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -13,13 +13,15 @@ final class MapSheetViewModel: ObservableObject {
     
     // MARK: - Properties
     
-    @Published var isLoading: Bool = false
+    @Published var isPlaceListLoading: Bool = false
+    @Published var isPlaceDetailLoading: Bool = true
     @Published var shouldShowErrorAlert: Bool = false
     
     @Published var cameraPosition: MapCameraPosition
-    @Published var sheetState: SheetState = .list
-    @Published var mapPlaces: [MapPlace] = []
+    @Published var sheetState: SheetState = .detail
     @Published var bottomSheetHeight: CGFloat = SheetState.defaultHeight
+    @Published var mapPlaces: [MapPlace] = MapPlace.mockData // PlaceListAPI 고쳐지면 다시 빈배열
+    @Published var placeDetail: PlaceDetail = PlaceDetail.skeletonData
     
     private let placeListService: PlaceListAPI
     
@@ -155,7 +157,7 @@ extension MapSheetViewModel {
 
 private extension MapSheetViewModel {
     func fetchPlaceList(request: PlaceListRequestDTO) async {
-        self.isLoading = true
+        self.isPlaceListLoading = true
         
         do {
             let response = try await placeListService.fetchPlaceList(request: request)
@@ -167,7 +169,7 @@ private extension MapSheetViewModel {
             }
             
             self.alertErrorMessage = ""
-            self.isLoading = false
+            self.isPlaceListLoading = false
             self.shouldShowErrorAlert =  false
             self.mapPlaces = data.placeList.map { MapPlace(from: $0) }
             

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -14,16 +14,19 @@ final class MapSheetViewModel: ObservableObject {
     // MARK: - Properties
     
     @Published var isPlaceListLoading: Bool = false
-    @Published var isPlaceDetailLoading: Bool = true
+    @Published var isPlaceDetailLoading: Bool = false
     @Published var shouldShowErrorAlert: Bool = false
     
     @Published var cameraPosition: MapCameraPosition
-    @Published var sheetState: SheetState = .detail
+    @Published var sheetState: SheetState = .list
     @Published var bottomSheetHeight: CGFloat = SheetState.defaultHeight
     @Published var mapPlaces: [MapPlace] = MapPlace.mockData // PlaceListAPI 고쳐지면 다시 빈배열
     @Published var placeDetail: PlaceDetail = PlaceDetail.skeletonData
     
     private let placeListService: PlaceListAPI
+    private let placeDetailService: PlaceDetailAPI
+    
+    private var fetchPlaceDetailTask: Task<Void, Never>?
     
     private let initialLocation = CLLocationCoordinate2D(latitude: 37.5598, longitude: 126.9770)
     private let span = MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
@@ -48,8 +51,9 @@ final class MapSheetViewModel: ObservableObject {
     
     // MARK: - Initializer
     
-    init(placeListService: PlaceListAPI) {
+    init(placeListService: PlaceListAPI, placeDetailService: PlaceDetailAPI) {
         self.placeListService = placeListService
+        self.placeDetailService = placeDetailService
         
         let adjustedCenter = CLLocationCoordinate2D(
             latitude: initialLocation.latitude - (span.latitudeDelta * spanRate),
@@ -74,9 +78,18 @@ final class MapSheetViewModel: ObservableObject {
             bottomSheetHeight = SheetState.minimumHeight
             
         case .showList:
+            fetchPlaceDetailTask?.cancel()
+            fetchPlaceDetailTask = nil
+            
+            placeDetail = PlaceDetail.skeletonData
             bottomSheetHeight = SheetState.defaultHeight
             
         case .selectMarker(let mapPlace):
+            fetchPlaceDetailTask?.cancel()
+            fetchPlaceDetailTask = Task {
+                await fetchPlaceDetail(placeId: 153)
+            }
+            
             selectMarker(mapPlace)
             setCameraPosition(coordinate: mapPlace.coordinate, spanRate: spanRate)
             sheetState = .detail
@@ -86,6 +99,11 @@ final class MapSheetViewModel: ObservableObject {
             }
             
         case .selectPlace(let mapPlace):
+            fetchPlaceDetailTask?.cancel()
+            fetchPlaceDetailTask = Task {
+                await fetchPlaceDetail(placeId: 153)
+            }
+            
             selectMarker(mapPlace)
             setCameraPosition(coordinate: mapPlace.coordinate, spanRate: spanRate)
             sheetState = .detail
@@ -96,6 +114,9 @@ final class MapSheetViewModel: ObservableObject {
                 break
                 
             case .detail:
+                fetchPlaceDetailTask?.cancel()
+                fetchPlaceDetailTask = nil
+                
                 deSelectMarker()
                 self.sheetState = .list
             }
@@ -170,16 +191,50 @@ private extension MapSheetViewModel {
             
             self.alertErrorMessage = ""
             self.isPlaceListLoading = false
-            self.shouldShowErrorAlert =  false
+            self.shouldShowErrorAlert = false
             self.mapPlaces = data.placeList.map { MapPlace(from: $0) }
             
         } catch let error as NetworkError {
             self.alertErrorMessage = error.alertMessage
-            self.shouldShowErrorAlert =  true
+            self.shouldShowErrorAlert = true
+            print(error)
             
         } catch {
             self.alertErrorMessage = NetworkError.unknownError.alertMessage
-            self.shouldShowErrorAlert =  true
+            self.shouldShowErrorAlert = true
+        }
+    }
+    
+    func fetchPlaceDetail(placeId: Int) async {
+        self.isPlaceDetailLoading = true
+        
+        do {
+            let response = try await placeDetailService.fetchPlaceDetail(placeId: placeId)
+            
+            try Task.checkCancellation()
+            
+            guard let data = response.data else {
+                self.alertErrorMessage = NetworkError.responseError.alertMessage
+                self.shouldShowErrorAlert = true
+                return
+            }
+            
+            self.alertErrorMessage = ""
+            self.isPlaceDetailLoading = false
+            self.shouldShowErrorAlert = false
+            self.placeDetail = PlaceDetail(from: data)
+            
+        } catch is CancellationError {
+            self.isPlaceDetailLoading = false
+            
+        } catch let error as NetworkError {
+            self.alertErrorMessage = error.alertMessage
+            self.shouldShowErrorAlert = true
+            print(error)
+            
+        } catch {
+            self.alertErrorMessage = NetworkError.unknownError.alertMessage
+            self.shouldShowErrorAlert = true
         }
     }
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 장소 상세 조회 구현했습니다
- 장소 상세 `skeleton` 구현했습니다
- 사용자가 마커를 여러 번 누르거나 & `list`로 갔다가 다시 `detail`로 오는 경우 즉, **장소 상세 API를 중복적으로 여러 번 호출**하는 경우 앞서 호출한 `Task`를 `cancel`하도록 구현했습니다

|    구현 내용    |   iPhone 13 mini   |   iPhone 17 pro   |
| :-------------: | :----------: | :----------: |
| 장소 상세 조회 | <img src = "https://github.com/user-attachments/assets/69134b9f-1073-4eb8-9630-7f370d7b1151" width ="250"> | <img src = "https://github.com/user-attachments/assets/23a96fc8-1a0c-4c65-8aa4-60b82e7d5850" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 장소 상세 정보 조회 기능 추가
  * 동적 이미지 로딩으로 시각적 개선
  * 가격, 설명 등 상세 정보 표시
  * 개별 로딩 상태 관리로 UX 향상
  * 스켈레톤 UI 커스터마이징 옵션 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->