### PR TITLE
[fix/#34] 바텀시트 너비 버그 수정

### DIFF
--- a/GG-iOS/GG-iOS/Global/Component/PlaceListRow.swift
+++ b/GG-iOS/GG-iOS/Global/Component/PlaceListRow.swift
@@ -100,7 +100,7 @@ extension PlaceListRow {
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .customSkeleton(with: isLoading)
-                    .frame(height: 80.adjustedHeight)
+                    .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
                     .background(.gray300)
                     .cornerRadius(10, corners: .allCorners)
             }

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -30,6 +30,7 @@ struct MapSheetView: View {
                     },
                     sheetContent: {
                         sheetContent
+                            .frame(width: 375.adjustedWidth)
                     }
                 )
             

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceDetailView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceDetailView.swift
@@ -54,7 +54,7 @@ extension PlaceDetailView {
         PlaceCuratorHeader(.detail) {
             onTap?()
         }
-        .padding(.horizontal, 20.adjustedWidth)
+        .padding(.leading, 20.adjustedWidth)
         .padding(.top, 20.adjustedHeight)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -62,12 +62,13 @@ extension PlaceDetailView {
     private var details: some View {
         VStack(alignment: .center, spacing: 20.adjustedHeight) {
             title
+                .padding(.horizontal, 20.adjustedWidth)
             
             photos
             
             informations
+                .padding(.horizontal, 20.adjustedWidth)
         }
-        .padding(.horizontal, 20.adjustedWidth)
     }
     
     private var title: some View {
@@ -77,7 +78,7 @@ extension PlaceDetailView {
             .lineLimit(1)
             .customSkeleton(
                 with: viewModel.isPlaceDetailLoading,
-                size: CGSize(width: 250.adjustedWidth, height: 33.adjustedHeight),
+                size: CGSize(width: 250.adjustedWidth, height: 35.adjustedHeight),
                 radius: 8
             )
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceListView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceListView.swift
@@ -38,7 +38,7 @@ struct PlaceListView: View {
 extension PlaceListView {
     private var header: some View {
         PlaceCuratorHeader(.list)
-            .padding(.horizontal, 20.adjustedWidth)
+            .padding(.leading, 20.adjustedWidth)
             .padding(.top, 20.adjustedHeight)
             .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -14,7 +14,7 @@ final class MapSheetViewModel: ObservableObject {
     // MARK: - Properties
     
     @Published var isPlaceListLoading: Bool = false
-    @Published var isPlaceDetailLoading: Bool = false
+    @Published var isPlaceDetailLoading: Bool = true
     @Published var shouldShowErrorAlert: Bool = false
     
     @Published var cameraPosition: MapCameraPosition
@@ -85,6 +85,9 @@ final class MapSheetViewModel: ObservableObject {
             bottomSheetHeight = SheetState.defaultHeight
             
         case .selectMarker(let mapPlace):
+            self.isPlaceDetailLoading = true
+            self.placeDetail = PlaceDetail.skeletonData
+            
             fetchPlaceDetailTask?.cancel()
             fetchPlaceDetailTask = Task {
                 // TODO: - 임시 placeId
@@ -100,6 +103,9 @@ final class MapSheetViewModel: ObservableObject {
             }
             
         case .selectPlace(let mapPlace):
+            self.isPlaceDetailLoading = true
+            self.placeDetail = PlaceDetail.skeletonData
+            
             fetchPlaceDetailTask?.cancel()
             fetchPlaceDetailTask = Task {
                 // TODO: - 임시 placeId


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 바텀시트 골반이 멈추지 않는 이슈를 수정했어요 ;;;

|    구현 내용    |   iPhone 13 mini   |   iPhone 17 pro   |
| :-------------: | :----------: | :----------: |
| 시트 너비 정상화 | <img src = "https://github.com/user-attachments/assets/561e82a3-af03-4172-acf4-170d363f81f5" width ="250"> | <img src = "https://github.com/user-attachments/assets/ff8ee439-2606-40a5-8b42-9a56a340b9c6" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #34 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일 및 레이아웃**
  * 사진 썸네일 크기 조정
  * 시트 콘텐츠 고정 너비 적용
  * 상세 정보 화면 패딩 및 정렬 개선
  * 제목 스켈레톤 높이 조정

* **개선사항**
  * 장소 정보 로딩 상태 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->