### PR TITLE
[feat/#36] 챗봇 대화 시작 API 연동

### DIFF
--- a/GG-iOS/GG-iOS/Global/Component/LoadingMessageBubble.swift
+++ b/GG-iOS/GG-iOS/Global/Component/LoadingMessageBubble.swift
@@ -1,0 +1,44 @@
+//
+//  LoadingMessageBubble.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/15/25.
+//
+
+import SwiftUI
+
+struct LoadingMessageBubble: View {
+    
+    // MARK: - Properties
+    
+    private let horizontalPadding: CGFloat = 20.adjustedWidth
+    private let extraHorizontalPadding: CGFloat = 59.adjustedWidth
+    
+    // MARK: - Body
+    
+    var body: some View {
+        HStack(alignment: .top, spacing: 7.adjustedWidth) {
+            Image(.chatbotOrangeIcon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 32.adjusted, height: 32.adjusted)
+            
+            VStack(alignment: .leading, spacing: 4.adjustedHeight) {
+                ProgressView()
+                    .scaleEffect(0.8)
+                    .padding(.vertical, 10.adjustedHeight)
+                    .padding(.horizontal, 12.adjustedWidth)
+                    .background(.gray100)
+                    .cornerRadius(10, corners: .allCorners)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, horizontalPadding)
+        .padding(.trailing, extraHorizontalPadding)
+    }
+}
+
+
+#Preview {
+    LoadingMessageBubble()
+}

--- a/GG-iOS/GG-iOS/Global/Component/LoadingQuestionList.swift
+++ b/GG-iOS/GG-iOS/Global/Component/LoadingQuestionList.swift
@@ -23,7 +23,7 @@ struct LoadingQuestionList: View {
     
     var body: some View {
         VStack(alignment: .center, spacing: 10.adjustedHeight) {
-            ForEach(0..<3) { _ in
+            ForEach(0..<count, id: \.self) { _ in
                 ProgressView()
                     .scaleEffect(0.8)
                     .frame(maxWidth: .infinity)

--- a/GG-iOS/GG-iOS/Global/Component/LoadingQuestionList.swift
+++ b/GG-iOS/GG-iOS/Global/Component/LoadingQuestionList.swift
@@ -1,0 +1,40 @@
+//
+//  LoadingQuestionList.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/15/25.
+//
+
+import SwiftUI
+
+struct LoadingQuestionList: View {
+    
+    // MARK: - Properties
+    
+    private let count: Int
+    
+    // MARK: - Initializer
+    
+    init(count: Int = 3) {
+        self.count = count
+    }
+    
+    // MARK: - Body
+    
+    var body: some View {
+        VStack(alignment: .center, spacing: 10.adjustedHeight) {
+            ForEach(0..<3) { _ in
+                ProgressView()
+                    .scaleEffect(0.8)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50.adjustedHeight)
+                    .addBorder(.roundedRectangle(cornerRadius: 10), borderColor: .gray200, borderWidth: 1)
+            }
+        }
+        .disabled(true)
+    }
+}
+
+#Preview {
+    LoadingQuestionList()
+}

--- a/GG-iOS/GG-iOS/Global/Component/QuestionRow.swift
+++ b/GG-iOS/GG-iOS/Global/Component/QuestionRow.swift
@@ -30,12 +30,13 @@ struct QuestionRow: View {
             Text(question)
                 .applyGGFont(.body02)
                 .foregroundStyle(.textNatural)
-                .padding(.vertical, 16.adjustedHeight)
                 .padding(.horizontal, 12.adjustedWidth)
+                .frame(height: 50.adjustedHeight)
                 .frame(maxWidth: .infinity)
                 .addBorder(.roundedRectangle(cornerRadius: 10), borderColor: .gray200, borderWidth: 1)
         }
         .buttonStyle(.plain)
+        .contentShape(Rectangle())
     }
 }
 

--- a/GG-iOS/GG-iOS/Global/Coordinator/AppDestination.swift
+++ b/GG-iOS/GG-iOS/Global/Coordinator/AppDestination.swift
@@ -8,15 +8,15 @@
 import SwiftUI
 
 enum AppDestination: Hashable {
-    case chat
+    case chat(placeId: Int, placeName: String, address: String)
 }
 
 extension AppDestination {
     @ViewBuilder
     func build() -> some View {
         switch self {
-        case .chat:
-            ChatView()
+        case .chat(let placeId, let placeName, let address):
+            ChatView(placeId: placeId, placeName: placeName, address: address)
         }
     }
 }

--- a/GG-iOS/GG-iOS/Network/DTO/Request/StartChatBotRequestDTO.swift
+++ b/GG-iOS/GG-iOS/Network/DTO/Request/StartChatBotRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  StartChatBotRequestDTO.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/15/25.
+//
+
+import Foundation
+
+struct StartChatBotRequestDTO: RequestModelType {
+    let placeId: Int
+}

--- a/GG-iOS/GG-iOS/Network/DTO/Response/StartChatBotResponseDTO.swift
+++ b/GG-iOS/GG-iOS/Network/DTO/Response/StartChatBotResponseDTO.swift
@@ -10,5 +10,5 @@ import Foundation
 struct StartChatBotResponseDTO: ResponseModelType {
     let answer: String
     let suggestedQuestions: [String]
-    let audioData: String
+    let audioData: String?
 }

--- a/GG-iOS/GG-iOS/Network/DTO/Response/StartChatBotResponseDTO.swift
+++ b/GG-iOS/GG-iOS/Network/DTO/Response/StartChatBotResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  StartChatBotResponseDTO.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/15/25.
+//
+
+import Foundation
+
+struct StartChatBotResponseDTO: ResponseModelType {
+    let answer: String
+    let suggestedQuestions: [String]
+    let audioData: String
+}

--- a/GG-iOS/GG-iOS/Network/Service/ChatBotService.swift
+++ b/GG-iOS/GG-iOS/Network/Service/ChatBotService.swift
@@ -1,0 +1,18 @@
+//
+//  ChatBotService.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/15/25.
+//
+
+import Foundation
+
+final class ChatBotService: BaseService<ChatBotTargetType> { }
+
+extension ChatBotService: ChatBotAPI {
+    func submitStartChatBot(
+        request: StartChatBotRequestDTO
+    ) async throws -> BaseResponseBody<StartChatBotResponseDTO> {
+        return try await self.request(with: .submitStartChatBot(request: request))
+    }
+}

--- a/GG-iOS/GG-iOS/Network/TargerType/ChatBotTargetType.swift
+++ b/GG-iOS/GG-iOS/Network/TargerType/ChatBotTargetType.swift
@@ -1,0 +1,37 @@
+//
+//  ChatBotTargetType.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/15/25.
+//
+
+import Foundation
+
+import Moya
+
+enum ChatBotTargetType {
+    case submitStartChatBot(request: StartChatBotRequestDTO)
+}
+
+extension ChatBotTargetType: BaseTargetType {
+    var path: String {
+        switch self {
+        case .submitStartChatBot:
+            return "/chatbot/start"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .submitStartChatBot:
+            return .post
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .submitStartChatBot(let request):
+            return .requestJSONEncodable(request)
+        }
+    }
+}

--- a/GG-iOS/GG-iOS/Presentation/Chat/API/ChatBotAPI.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/API/ChatBotAPI.swift
@@ -1,0 +1,15 @@
+//
+//  ChatBotAPI.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/15/25.
+//
+
+import Foundation
+
+protocol ChatBotAPI {
+    /// 챗봇 대화 시작
+    func submitStartChatBot(
+        request: StartChatBotRequestDTO
+    ) async throws -> BaseResponseBody<StartChatBotResponseDTO>
+}

--- a/GG-iOS/GG-iOS/Presentation/Chat/API/TempChatAPI.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/API/TempChatAPI.swift
@@ -1,8 +1,0 @@
-//
-//  TempChatAPI.swift
-//  GG-iOS
-//
-//  Created by 김승원 on 11/12/25.
-//
-
-import Foundation

--- a/GG-iOS/GG-iOS/Presentation/Chat/View/ChatView.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/View/ChatView.swift
@@ -12,7 +12,20 @@ struct ChatView: View {
     // MARK: - Properties
     
     @EnvironmentObject private var appCoordinator: AppCoordinator
-    @StateObject private var viewModel = ChatViewModel()
+    @StateObject private var viewModel: ChatViewModel
+    
+    // MARK: - Initializer
+    
+    init(placeId: Int, placeName: String, address: String) {
+        self._viewModel = StateObject(
+            wrappedValue: ChatViewModel(
+                chatBotService: ChatBotService(),
+                placeId: 153,
+                placeName: "Suwon Hwaseong1",
+                address: "175, Mallijae-ro, Jung-gu, Seoul, Republic of Korea"
+            )
+        )
+    }
     
     // MARK: - Body
     
@@ -27,6 +40,9 @@ struct ChatView: View {
         .customNavigationBar(.chat(backAction: {
             appCoordinator.goBack()
         }))
+        .onAppear {
+            viewModel.dispatch(.submitStartChatBot)
+        }
     }
 }
 
@@ -36,7 +52,7 @@ extension ChatView {
     private var header: some View {
         VStack(alignment: .center, spacing: 0) {
             VStack(alignment: .leading, spacing: 4.adjustedHeight) {
-                Text("Suwon Hwaseong")
+                Text(viewModel.placeName)
                     .applyGGFont(.heading02)
                     .foregroundStyle(.textNatural)
                     .lineLimit(1)
@@ -47,7 +63,7 @@ extension ChatView {
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 12.adjusted, height: 12.adjusted)
                     
-                    Text("320-2 Hwajeong-dong, Jangan-gu, Suwon-si")
+                    Text(viewModel.address)
                         .applyGGFont(.label02)
                         .foregroundStyle(.textLight)
                         .lineLimit(1)
@@ -120,6 +136,6 @@ extension ChatView {
 }
 
 #Preview {
-    ChatView()
+    ChatView(placeId: 153, placeName: "Example", address: "Example address-123")
         .environmentObject(AppCoordinator())
 }

--- a/GG-iOS/GG-iOS/Presentation/Chat/View/ChatView.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/View/ChatView.swift
@@ -22,7 +22,7 @@ struct ChatView: View {
                 chatBotService: ChatBotService(),
                 placeId: 153,
                 placeName: "Suwon Hwaseong1",
-                address: "175, Mallijae-ro, Jung-gu, Seoul, Republic of Korea"
+                address: "175, Mallijae-ro, Jung-gu, Seoul, Republic of Korea1"
             )
         )
     }
@@ -88,8 +88,13 @@ extension ChatView {
                 ForEach(viewModel.chatMessages, id: \.id) { message in
                     MessageBubble(chatMessage: message)
                 }
+                
+                if viewModel.isChatBotLoading {
+                    LoadingMessageBubble()
+                }
             }
             .padding(.vertical, 28.adjustedHeight)
+            
         }
         .frame(maxWidth: .infinity)
         .background(.gray0)
@@ -111,7 +116,9 @@ extension ChatView {
                     Spacer()
                     
                     Button {
-                        
+                        withAnimation(nil) {
+                            viewModel.dispatch(.updateQuestions)
+                        }
                     } label: {
                         Image(.refreshIcon)
                             .resizable()
@@ -119,15 +126,22 @@ extension ChatView {
                             .frame(width: 24.adjusted, height: 24.adjusted)
                     }
                     .buttonStyle(.plain)
+                    .contentShape(Rectangle())
                 }
                 .padding(.horizontal, 24.adjustedWidth)
                 .frame(height: 24.adjustedHeight)
                 
-                // 임시 질문 list
-                VStack(alignment: .center, spacing: 10.adjustedHeight) {
-                    QuestionRow(question: "Are you curious about Suwon Hwaseong?")
-                    QuestionRow(question: "Are you curious about Suwon Hwaseong?")
-                    QuestionRow(question: "Are you curious about Suwon Hwaseong?")
+                Group {
+                    if viewModel.isQuestionLoading {
+                        LoadingQuestionList()
+                    } else {
+                        LazyVStack(alignment: .center, spacing: 10.adjustedHeight) {
+                            ForEach(viewModel.questions, id: \.self) { question in
+                                QuestionRow(question: question)
+                            }
+                        }
+                        .disabled(viewModel.isChatBotLoading)
+                    }
                 }
                 .padding(.horizontal, 27.adjustedWidth)
             }

--- a/GG-iOS/GG-iOS/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -12,8 +12,10 @@ final class ChatViewModel: ObservableObject {
     
     // MARK: - Properties
     
-    @Published var isLoading: Bool = true
-    @Published var chatMessages: [ChatMessage] = ChatMessage.mockData
+    @Published var isChatBotLoading: Bool = true
+    @Published var isQuestionLoading: Bool = true
+    @Published var chatMessages: [ChatMessage] = []
+    @Published var questions: [String] = []
     
     private let chatBotService: ChatBotAPI
     
@@ -21,9 +23,12 @@ final class ChatViewModel: ObservableObject {
     let placeName: String
     let address: String
     
+    private var suggestedQuestions: [String] = []
+    
     // MARK: - Action
     
     enum Action {
+        case updateQuestions
 
         // api
         case submitStartChatBot
@@ -47,8 +52,12 @@ final class ChatViewModel: ObservableObject {
     
     func dispatch(_ action: Action) {
         switch action {
+        case .updateQuestions:
+            updateRandomQuestions()
+            
         case .submitStartChatBot:
-            isLoading = true
+            isChatBotLoading = true
+            isQuestionLoading = true
             
             Task {
                 await submitStartChatBot(
@@ -61,6 +70,31 @@ final class ChatViewModel: ObservableObject {
     }
 }
 
+// MARK: - Private Functions
+
+private extension ChatViewModel {
+    func appendChatMessage(
+        sender: Sender,
+        message: String,
+        audioString: String?
+    ) {
+        // TODO: - AudioString -> AudioData 변환 필요
+        
+        chatMessages.append(
+            ChatMessage(
+                sender: sender,
+                message: message,
+                audioData: nil // 임시 nil
+            )
+        )
+    }
+    
+    func updateRandomQuestions() {
+        questions = Array(suggestedQuestions.shuffled().prefix(3))
+        isQuestionLoading = false
+    }
+}
+
 // MARK: - API
 
 private extension ChatViewModel {
@@ -70,10 +104,23 @@ private extension ChatViewModel {
             
             guard let data = response.data else { return }
             
+            isChatBotLoading = false
+            suggestedQuestions = data.suggestedQuestions
+            updateRandomQuestions()
+            appendChatMessage(
+                sender: .chatBot,
+                message: data.answer,
+                audioString: data.audioData
+            )
+            
+            print(questions)
+            
         } catch let error as NetworkError {
-            
+            isChatBotLoading = false
+            print(error)
         } catch {
-            
+            isChatBotLoading = false
+            print(NetworkError.unknownError)
         }
     }
 }

--- a/GG-iOS/GG-iOS/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -113,8 +113,6 @@ private extension ChatViewModel {
                 audioString: data.audioData
             )
             
-            print(questions)
-            
         } catch let error as NetworkError {
             isChatBotLoading = false
             print(error)

--- a/GG-iOS/GG-iOS/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -7,14 +7,73 @@
 
 import SwiftUI
 
+@MainActor
 final class ChatViewModel: ObservableObject {
     
     // MARK: - Properties
     
-    @Published var placeName: String = ""
-    @Published var address: String = ""
+    @Published var isLoading: Bool = true
     @Published var chatMessages: [ChatMessage] = ChatMessage.mockData
     
+    private let chatBotService: ChatBotAPI
+    
+    private let placeId: Int
+    let placeName: String
+    let address: String
+    
     // MARK: - Action
+    
+    enum Action {
 
+        // api
+        case submitStartChatBot
+    }
+    
+    // MARK: - Initializer
+    
+    init(
+        chatBotService: ChatBotAPI,
+        placeId: Int,
+        placeName: String,
+        address: String
+    ) {
+        self.chatBotService = chatBotService
+        self.placeId = placeId
+        self.placeName = placeName
+        self.address = address
+    }
+    
+    // MARK: - Dispatch
+    
+    func dispatch(_ action: Action) {
+        switch action {
+        case .submitStartChatBot:
+            isLoading = true
+            
+            Task {
+                await submitStartChatBot(
+                    request: StartChatBotRequestDTO(
+                        placeId: placeId
+                    )
+                )
+            }
+        }
+    }
+}
+
+// MARK: - API
+
+private extension ChatViewModel {
+    func submitStartChatBot(request: StartChatBotRequestDTO) async {
+        do {
+            let response = try await chatBotService.submitStartChatBot(request: request)
+            
+            guard let data = response.data else { return }
+            
+        } catch let error as NetworkError {
+            
+        } catch {
+            
+        }
+    }
 }

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/Model/PlaceDetail.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/Model/PlaceDetail.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct PlaceDetail {
+    let placeId: Int
     let placeName: String
     let imageUrlStrings: [String]
     let address: String
@@ -18,6 +19,7 @@ struct PlaceDetail {
 
 extension PlaceDetail {
     init(from dto: PlaceDetailResponseDTO) {
+        self.placeId = dto.placeId
         self.placeName = dto.placeName
         self.imageUrlStrings = dto.placeImages
         self.address = dto.address
@@ -30,6 +32,7 @@ extension PlaceDetail {
 extension PlaceDetail {
     static var mockData: PlaceDetail {
         return PlaceDetail(
+            placeId: 1,
             placeName: "Suwon Hwaseong1",
             imageUrlStrings: TempImageUrlString.threeImageUrlStrings(),
             address: "320-2 Hwajeong-dong, Jangan-gu, Suwon-si",
@@ -43,6 +46,7 @@ extension PlaceDetail {
 extension PlaceDetail {
     static var skeletonData: PlaceDetail {
         return PlaceDetail(
+            placeId: 1,
             placeName: "",
             imageUrlStrings: ["1", "2", "3"],
             address: "",

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -13,10 +13,18 @@ struct MapSheetView: View {
     // MARK: - Properties
     
     @EnvironmentObject private var appCoordinator: AppCoordinator
-    @StateObject private var viewModel = MapSheetViewModel(
-        placeListService: PlaceListService(),
-        placeDetailService: PlaceDetailService()
-    )
+    @StateObject private var viewModel: MapSheetViewModel
+    
+    // MARK: - Initializer
+    
+    init() {
+        self._viewModel = StateObject(
+            wrappedValue: MapSheetViewModel(
+                placeListService: PlaceListService(),
+                placeDetailService: PlaceDetailService()
+            )
+        )
+    }
     
     // MARK: - Body
     
@@ -160,8 +168,14 @@ extension MapSheetView {
             case .list:
                 PlaceListView(viewModel: viewModel)
             case .detail:
-                PlaceDetailView(viewModel: viewModel) {
-                    appCoordinator.navigate(to: .chat)
+                PlaceDetailView(viewModel: viewModel) { placeId, placeName, address in
+                    appCoordinator.navigate(
+                        to: .chat(
+                            placeId: placeId,
+                            placeName: placeName,
+                            address: address
+                        )
+                    )
                 }
             }
         }

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -143,6 +143,7 @@ extension MapSheetView {
                 .animation(.easeInOut(duration: 0.1), value: viewModel.sheetState)
             }
             .buttonStyle(.plain)
+            .contentShape(Rectangle())
             
             HStack(alignment: .center, spacing: 0) {
                 Button {

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceDetailView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceDetailView.swift
@@ -15,11 +15,11 @@ struct PlaceDetailView: View {
     
     @ObservedObject private var viewModel: MapSheetViewModel
     
-    private let onTap: (() -> Void)?
+    private let onTap: ((Int, String, String) -> Void)?
     
     // MARK: - Initializer
     
-    init(viewModel: MapSheetViewModel, onTap: (() -> Void)? = nil) {
+    init(viewModel: MapSheetViewModel, onTap: ((Int, String, String) -> Void)? = nil) {
         self.viewModel = viewModel
         self.onTap = onTap
     }
@@ -52,7 +52,11 @@ struct PlaceDetailView: View {
 extension PlaceDetailView {
     private var header: some View {
         PlaceCuratorHeader(.detail) {
-            onTap?()
+            onTap?(
+                viewModel.placeDetail.placeId,
+                viewModel.placeDetail.placeName,
+                viewModel.placeDetail.address
+            )
         }
         .padding(.leading, 20.adjustedWidth)
         .padding(.top, 20.adjustedHeight)

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -13,7 +13,7 @@ final class MapSheetViewModel: ObservableObject {
     
     // MARK: - Properties
     
-    @Published var isPlaceListLoading: Bool = false
+    @Published var isPlaceListLoading: Bool = true
     @Published var isPlaceDetailLoading: Bool = true
     @Published var shouldShowErrorAlert: Bool = false
     
@@ -26,7 +26,6 @@ final class MapSheetViewModel: ObservableObject {
     
     private let placeListService: PlaceListAPI
     private let placeDetailService: PlaceDetailAPI
-    
     private var fetchPlaceDetailTask: Task<Void, Never>?
     
     private let initialLocation = CLLocationCoordinate2D(latitude: 37.5598, longitude: 126.9770)
@@ -38,7 +37,6 @@ final class MapSheetViewModel: ObservableObject {
     // MARK: - Action
     
     enum Action {
-    
         case setCameraToUser
         case showMap
         case showList
@@ -52,7 +50,10 @@ final class MapSheetViewModel: ObservableObject {
     
     // MARK: - Initializer
     
-    init(placeListService: PlaceListAPI, placeDetailService: PlaceDetailAPI) {
+    init(
+        placeListService: PlaceListAPI,
+        placeDetailService: PlaceDetailAPI
+    ) {
         self.placeListService = placeListService
         self.placeDetailService = placeDetailService
         
@@ -131,6 +132,8 @@ final class MapSheetViewModel: ObservableObject {
             }
             
         case .fetchPlaceList:
+            self.isPlaceDetailLoading = true
+            
             Task {
                 await fetchPlaceList(
                     request: PlaceListRequestDTO(
@@ -187,8 +190,6 @@ extension MapSheetViewModel {
 
 private extension MapSheetViewModel {
     func fetchPlaceList(request: PlaceListRequestDTO) async {
-        self.isPlaceListLoading = true
-        
         do {
             let response = try await placeListService.fetchPlaceList(request: request)
             
@@ -215,8 +216,6 @@ private extension MapSheetViewModel {
     }
     
     func fetchPlaceDetail(placeId: Int) async {
-        self.isPlaceDetailLoading = true
-        
         do {
             let response = try await placeDetailService.fetchPlaceDetail(placeId: placeId)
             


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 챗봇 대화 시작 API 연동
- 챗봇 시작시 로딩 구현

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| 챗봇 대화 시작 API 연동 | <img src = "https://github.com/user-attachments/assets/f73a3871-ab8f-4c7c-8967-83673647440a" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #36 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 챗봇 초기 응답 기능 추가 및 장소 정보 기반 채팅 시작 지원
  * 동적 추천 질문 목록 로딩 및 표시 기능 추가
  * 채팅 화면에 로딩 메시지 및 로딩 질문 리스트 표시

* **개선사항**
  * 로딩 상태 시각화 강화(채팅 버블 및 진행 표시)
  * 질문 목록 및 버튼의 터치 영역·상호작용 개선
  * 장소 상세에서 채팅으로 이동 시 장소 정보 전달 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->