### PR TITLE
[feat/#40] 챗봇 이어가기 API 연동

### DIFF
--- a/GG-iOS/GG-iOS/Global/Component/PlaceListRow.swift
+++ b/GG-iOS/GG-iOS/Global/Component/PlaceListRow.swift
@@ -95,23 +95,21 @@ extension PlaceListRow {
     
     private var photos: some View {
         HStack(alignment: .center, spacing: 2.5.adjustedWidth) {
-            if imageUrlStrings.isEmpty {
-                ForEach(0..<3) { _ in
-                    Rectangle()
-                        .foregroundStyle(.gray300)
-                        .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
-                        .cornerRadius(10, corners: .allCorners)
-                }
-            } else {
-                ForEach(imageUrlStrings, id: \.self) { imageString in
-                    KFImage(URL(string: imageString))
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .customSkeleton(with: isLoading)
-                        .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
-                        .background(.gray300)
-                        .cornerRadius(10, corners: .allCorners)
-                }
+            ForEach(imageUrlStrings, id: \.self) { imageString in
+                KFImage(URL(string: imageString))
+                    .onFailureImage(.tempImageIcon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .customSkeleton(with: isLoading)
+                    .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
+                    .background(.gray300)
+                    .cornerRadius(10, corners: .allCorners)
+            }
+            
+            ForEach(0..<(3 - imageUrlStrings.count), id: \.self) { _ in
+                Image(.tempImageIcon)
+                    .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
+                    .cornerRadius(10, corners: .allCorners)
             }
         }
     }

--- a/GG-iOS/GG-iOS/Global/Component/PlaceListRow.swift
+++ b/GG-iOS/GG-iOS/Global/Component/PlaceListRow.swift
@@ -95,14 +95,23 @@ extension PlaceListRow {
     
     private var photos: some View {
         HStack(alignment: .center, spacing: 2.5.adjustedWidth) {
-            ForEach(imageUrlStrings, id: \.self) { imageString in
-                KFImage(URL(string: imageString))
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .customSkeleton(with: isLoading)
-                    .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
-                    .background(.gray300)
-                    .cornerRadius(10, corners: .allCorners)
+            if imageUrlStrings.isEmpty {
+                ForEach(0..<3) { _ in
+                    Rectangle()
+                        .foregroundStyle(.gray300)
+                        .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
+                        .cornerRadius(10, corners: .allCorners)
+                }
+            } else {
+                ForEach(imageUrlStrings, id: \.self) { imageString in
+                    KFImage(URL(string: imageString))
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .customSkeleton(with: isLoading)
+                        .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
+                        .background(.gray300)
+                        .cornerRadius(10, corners: .allCorners)
+                }
             }
         }
     }

--- a/GG-iOS/GG-iOS/Global/Component/ThreeDividedPhoto.swift
+++ b/GG-iOS/GG-iOS/Global/Component/ThreeDividedPhoto.swift
@@ -1,0 +1,93 @@
+//
+//  ThreeDividedPhoto.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/16/25.
+//
+
+import SwiftUI
+
+import Kingfisher
+
+struct ThreeDividedPhoto: View {
+    
+    // MARK: - Properties
+    
+    private let imageUrlStrings: [String]
+    private let isLoading: Bool
+    
+    // MARK: - Initializer
+    
+    init(imageUrlStrings: [String], isLoading: Bool) {
+        self.imageUrlStrings = imageUrlStrings
+        self.isLoading = isLoading
+    }
+    
+    // MARK: - Body
+    
+    var body: some View {
+        HStack(alignment: .center, spacing: 8.adjustedWidth) {
+            if imageUrlStrings.count < 1 {
+                tempImage
+                    .frame(width: 218.adjustedWidth, height: 168.adjustedHeight)
+                    .cornerRadius(10, corners: .allCorners)
+            } else {
+                KFImage(URL(string: imageUrlStrings[0]))
+                    .onFailureImage(.tempImageIcon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .customSkeleton(with: isLoading)
+                    .frame(width: 218.adjustedWidth, height: 168.adjustedHeight)
+                    .cornerRadius(10, corners: .allCorners)
+            }
+            
+            VStack(alignment: .center, spacing: 8.adjustedHeight) {
+                if imageUrlStrings.count < 2 {
+                    tempImage
+                        .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
+                        .cornerRadius(10, corners: .allCorners)
+                } else {
+                    KFImage(URL(string: imageUrlStrings[1]))
+                        .onFailureImage(.tempImageIcon)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .customSkeleton(with: isLoading)
+                        .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
+                        .cornerRadius(10, corners: .allCorners)
+                }
+                
+                if imageUrlStrings.count < 3 {
+                    tempImage
+                        .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
+                        .cornerRadius(10, corners: .allCorners)
+                } else {
+                    KFImage(URL(string: imageUrlStrings[2]))
+                        .onFailureImage(.tempImageIcon)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .customSkeleton(with: isLoading)
+                        .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
+                        .cornerRadius(10, corners: .allCorners)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Subviews
+
+extension ThreeDividedPhoto {
+    private var tempImage: some View {
+        Image(.tempImageIcon)
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .customSkeleton(with: isLoading)
+    }
+}
+
+#Preview {
+    ThreeDividedPhoto(
+        imageUrlStrings: [],
+        isLoading: false
+    )
+}

--- a/GG-iOS/GG-iOS/Network/DTO/Request/RelayChatBotRequestDTO.swift
+++ b/GG-iOS/GG-iOS/Network/DTO/Request/RelayChatBotRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  RelayChatBotRequestDTO.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/15/25.
+//
+
+import Foundation
+
+struct RelayChatBotRequestDTO: RequestModelType {
+    let placeId: Int
+    let question: String
+}

--- a/GG-iOS/GG-iOS/Network/DTO/Response/PlaceDetailResponseDTO.swift
+++ b/GG-iOS/GG-iOS/Network/DTO/Response/PlaceDetailResponseDTO.swift
@@ -12,7 +12,7 @@ struct PlaceDetailResponseDTO: ResponseModelType {
     let placeName: String
     let address: String
     let placeImages: [String]
-    let locationExplain: String
+    let locationExplain: String?
     let price: String?
     let inquiry: String
 }

--- a/GG-iOS/GG-iOS/Network/DTO/Response/RelayChatBotResponseDTO.swift
+++ b/GG-iOS/GG-iOS/Network/DTO/Response/RelayChatBotResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  RelayChatBotResponseDTO.swift
+//  GG-iOS
+//
+//  Created by 김승원 on 11/15/25.
+//
+
+import Foundation
+
+struct RelayChatBotResponseDTO: ResponseModelType {
+    let answer: String
+    let audioData: String
+}

--- a/GG-iOS/GG-iOS/Network/Service/ChatBotService.swift
+++ b/GG-iOS/GG-iOS/Network/Service/ChatBotService.swift
@@ -15,4 +15,11 @@ extension ChatBotService: ChatBotAPI {
     ) async throws -> BaseResponseBody<StartChatBotResponseDTO> {
         return try await self.request(with: .submitStartChatBot(request: request))
     }
+    
+    func submitRelayChatBot(
+        request: RelayChatBotRequestDTO
+    ) async throws -> BaseResponseBody<RelayChatBotResponseDTO> {
+        return try await self.request(with: .submitRelayChatBot(request: request))
+    }
+    
 }

--- a/GG-iOS/GG-iOS/Network/TargerType/ChatBotTargetType.swift
+++ b/GG-iOS/GG-iOS/Network/TargerType/ChatBotTargetType.swift
@@ -11,6 +11,7 @@ import Moya
 
 enum ChatBotTargetType {
     case submitStartChatBot(request: StartChatBotRequestDTO)
+    case submitRelayChatBot(request: RelayChatBotRequestDTO)
 }
 
 extension ChatBotTargetType: BaseTargetType {
@@ -18,6 +19,8 @@ extension ChatBotTargetType: BaseTargetType {
         switch self {
         case .submitStartChatBot:
             return "/chatbot/start"
+        case .submitRelayChatBot:
+            return "/chatBot/relay"
         }
     }
     
@@ -25,12 +28,16 @@ extension ChatBotTargetType: BaseTargetType {
         switch self {
         case .submitStartChatBot:
             return .post
+        case .submitRelayChatBot:
+            return .post
         }
     }
     
     var task: Moya.Task {
         switch self {
         case .submitStartChatBot(let request):
+            return .requestJSONEncodable(request)
+        case .submitRelayChatBot(let request):
             return .requestJSONEncodable(request)
         }
     }

--- a/GG-iOS/GG-iOS/Network/TargerType/ChatBotTargetType.swift
+++ b/GG-iOS/GG-iOS/Network/TargerType/ChatBotTargetType.swift
@@ -20,7 +20,7 @@ extension ChatBotTargetType: BaseTargetType {
         case .submitStartChatBot:
             return "/chatbot/start"
         case .submitRelayChatBot:
-            return "/chatBot/relay"
+            return "/chatbot/relay"
         }
     }
     

--- a/GG-iOS/GG-iOS/Network/TargerType/ChatBotTargetType.swift
+++ b/GG-iOS/GG-iOS/Network/TargerType/ChatBotTargetType.swift
@@ -36,9 +36,15 @@ extension ChatBotTargetType: BaseTargetType {
     var task: Moya.Task {
         switch self {
         case .submitStartChatBot(let request):
-            return .requestJSONEncodable(request)
+            return .requestCompositeData(
+                bodyData: (try? JSONEncoder().encode(request)) ?? Data(),
+                urlParameters: ["enableTts": false]
+            )
         case .submitRelayChatBot(let request):
-            return .requestJSONEncodable(request)
+            return .requestCompositeData(
+                bodyData: (try? JSONEncoder().encode(request)) ?? Data(),
+                urlParameters: ["enableTts": true]
+            )
         }
     }
 }

--- a/GG-iOS/GG-iOS/Presentation/Chat/API/ChatBotAPI.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/API/ChatBotAPI.swift
@@ -12,4 +12,9 @@ protocol ChatBotAPI {
     func submitStartChatBot(
         request: StartChatBotRequestDTO
     ) async throws -> BaseResponseBody<StartChatBotResponseDTO>
+    
+    /// 챗봇 대화 이어가기
+    func submitRelayChatBot(
+        request: RelayChatBotRequestDTO
+    ) async throws -> BaseResponseBody<RelayChatBotResponseDTO>
 }

--- a/GG-iOS/GG-iOS/Presentation/Chat/Model/ChatMessage.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/Model/ChatMessage.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ChatMessage: Identifiable {
+struct ChatMessage: Identifiable, Equatable {
     let id = UUID()
     let sender: Sender
     let message: String

--- a/GG-iOS/GG-iOS/Presentation/Chat/View/ChatView.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/View/ChatView.swift
@@ -20,9 +20,9 @@ struct ChatView: View {
         self._viewModel = StateObject(
             wrappedValue: ChatViewModel(
                 chatBotService: ChatBotService(),
-                placeId: 153,
-                placeName: "Suwon Hwaseong1",
-                address: "175, Mallijae-ro, Jung-gu, Seoul, Republic of Korea1"
+                placeId: placeId,
+                placeName: placeName,
+                address: address
             )
         )
     }

--- a/GG-iOS/GG-iOS/Presentation/Chat/View/ChatView.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/View/ChatView.swift
@@ -83,18 +83,34 @@ extension ChatView {
     }
     
     private var chat: some View {
-        ScrollView(.vertical) {
-            LazyVStack(alignment: .center, spacing: 12.adjustedHeight) {
-                ForEach(viewModel.chatMessages, id: \.id) { message in
-                    MessageBubble(chatMessage: message)
+        ScrollViewReader { proxy in
+            ScrollView(.vertical) {
+                LazyVStack(alignment: .center, spacing: 12.adjustedHeight) {
+                    ForEach(viewModel.chatMessages, id: \.id) { message in
+                        MessageBubble(chatMessage: message)
+                    }
+                    
+                    if viewModel.isChatBotLoading {
+                        LoadingMessageBubble()
+                    }
+                    
+                    Rectangle()
+                        .foregroundStyle(.gray0)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 28.adjustedHeight)
+                        .id("scrollToBottom")
                 }
-                
-                if viewModel.isChatBotLoading {
-                    LoadingMessageBubble()
+                .padding(.top, 28.adjustedHeight)
+            }
+            .onChange(of: viewModel.chatMessages.count) { _, _ in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    withAnimation(.easeOut(duration: 0.25)) {
+                        proxy.scrollTo("scrollToBottom", anchor: .bottom)
+                    }
                 }
             }
-            .padding(.vertical, 28.adjustedHeight)
-            
+
+
         }
         .frame(maxWidth: .infinity)
         .background(.gray0)

--- a/GG-iOS/GG-iOS/Presentation/Chat/View/ChatView.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/View/ChatView.swift
@@ -127,22 +127,19 @@ extension ChatView {
                     }
                     .buttonStyle(.plain)
                     .contentShape(Rectangle())
+                    .disabled(viewModel.isChatBotLoading)
                 }
                 .padding(.horizontal, 24.adjustedWidth)
                 .frame(height: 24.adjustedHeight)
                 
-                Group {
-                    if viewModel.isQuestionLoading {
-                        LoadingQuestionList()
-                    } else {
-                        LazyVStack(alignment: .center, spacing: 10.adjustedHeight) {
-                            ForEach(viewModel.questions, id: \.self) { question in
-                                QuestionRow(question: question)
-                            }
+                LazyVStack(alignment: .center, spacing: 10.adjustedHeight) {
+                    ForEach(viewModel.questions, id: \.self) { question in
+                        QuestionRow(question: question) {
+                            viewModel.dispatch(.submitRelayChatBot(question: question))
                         }
-                        .disabled(viewModel.isChatBotLoading)
                     }
                 }
+                .disabled(viewModel.isChatBotLoading)
                 .padding(.horizontal, 27.adjustedWidth)
             }
         }

--- a/GG-iOS/GG-iOS/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -32,6 +32,7 @@ final class ChatViewModel: ObservableObject {
 
         // api
         case submitStartChatBot
+        case submitRelayChatBot(question: String)
     }
     
     // MARK: - Initializer
@@ -66,6 +67,24 @@ final class ChatViewModel: ObservableObject {
                     )
                 )
             }
+            
+        case .submitRelayChatBot(let question):
+            isChatBotLoading = true
+            
+            appendChatMessage(
+                sender: .user,
+                message: question,
+                audioString: nil
+            )
+            
+            Task {
+                await submitRelayChatBot(
+                    request: RelayChatBotRequestDTO(
+                        placeId: placeId,
+                        question: question
+                    )
+                )
+            }
         }
     }
 }
@@ -80,17 +99,22 @@ private extension ChatViewModel {
     ) {
         // TODO: - AudioString -> AudioData 변환 필요
         
-        chatMessages.append(
-            ChatMessage(
-                sender: sender,
-                message: message,
-                audioData: nil // 임시 nil
+        withAnimation(.easeInOut(duration: 0.2)) {
+            chatMessages.append(
+                ChatMessage(
+                    sender: sender,
+                    message: message,
+                    audioData: nil // 임시 nil
+                )
             )
-        )
+        }
     }
     
     func updateRandomQuestions() {
-        questions = Array(suggestedQuestions.shuffled().prefix(3))
+        withAnimation(.easeInOut(duration: 0.2)) {
+            questions = Array(suggestedQuestions.shuffled().prefix(3))
+        }
+        
         isQuestionLoading = false
     }
 }
@@ -114,10 +138,28 @@ private extension ChatViewModel {
             )
             
         } catch let error as NetworkError {
-            isChatBotLoading = false
             print(error)
         } catch {
+            print(NetworkError.unknownError)
+        }
+    }
+    
+    func submitRelayChatBot(request: RelayChatBotRequestDTO) async {
+        do {
+            let response = try await chatBotService.submitRelayChatBot(request: request)
+            
+            guard let data = response.data else { return }
+            
             isChatBotLoading = false
+            appendChatMessage(
+                sender: .chatBot,
+                message: data.answer,
+                audioString: data.audioData
+            )
+            
+        } catch let error as NetworkError {
+            print(error)
+        } catch {
             print(NetworkError.unknownError)
         }
     }

--- a/GG-iOS/GG-iOS/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -85,6 +85,7 @@ final class ChatViewModel: ObservableObject {
                     )
                 )
             }
+            
         }
     }
 }
@@ -111,12 +112,22 @@ private extension ChatViewModel {
     }
     
     func updateRandomQuestions() {
+        let filtered = suggestedQuestions.filter { !questions.contains($0) }
+        
+        let newQuestions: [String]
+        if filtered.count < 3 {
+            newQuestions = Array(suggestedQuestions.shuffled().prefix(3))
+        } else {
+            newQuestions = Array(filtered.shuffled().prefix(3))
+        }
+        
         withAnimation(.easeInOut(duration: 0.2)) {
-            questions = Array(suggestedQuestions.shuffled().prefix(3))
+            questions = newQuestions
         }
         
         isQuestionLoading = false
     }
+
 }
 
 // MARK: - API
@@ -156,6 +167,7 @@ private extension ChatViewModel {
                 message: data.answer,
                 audioString: data.audioData
             )
+            updateRandomQuestions()
             
         } catch let error as NetworkError {
             print(error)

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/Model/PlaceDetail.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/Model/PlaceDetail.swift
@@ -14,7 +14,7 @@ struct PlaceDetail {
     let address: String
     let inquiry: String
     let price: String?
-    let description: String
+    let description: String?
 }
 
 extension PlaceDetail {

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -45,7 +45,7 @@ struct MapSheetView: View {
             address
         }
         .onAppear {
-            viewModel.dispatch(.fetchPlaceList)
+//            viewModel.dispatch(.fetchPlaceList)
         }
         .alert(isPresented: $viewModel.shouldShowErrorAlert) {
             Alert(

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -164,11 +164,10 @@ extension MapSheetView {
     }
     
     private var sheetContent: some View {
-        Group {
-            switch viewModel.sheetState {
-            case .list:
-                PlaceListView(viewModel: viewModel)
-            case .detail:
+        ZStack(alignment: .center) {
+            PlaceListView(viewModel: viewModel)
+            
+            if viewModel.sheetState == .detail {
                 PlaceDetailView(viewModel: viewModel) { placeId, placeName, address in
                     appCoordinator.navigate(
                         to: .chat(

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/MapSheetView.swift
@@ -45,7 +45,7 @@ struct MapSheetView: View {
             address
         }
         .onAppear {
-//            viewModel.dispatch(.fetchPlaceList)
+            viewModel.dispatch(.fetchPlaceList)
         }
         .alert(isPresented: $viewModel.shouldShowErrorAlert) {
             Alert(

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceDetailView.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/View/PlaceDetailView.swift
@@ -35,14 +35,17 @@ struct PlaceDetailView: View {
                 details
                     .padding(.bottom, 24.adjustedHeight)
                 
-                divider
-                    .padding(.bottom, 24.adjustedHeight)
-                
-                description
+                if viewModel.placeDetail.description != nil {
+                    divider
+                        .padding(.bottom, 24.adjustedHeight)
+                    
+                    description
+                }
                 
                 scrollSpacer
             }
         }
+        .background(.gray0)
         .disabled(viewModel.isPlaceDetailLoading)
     }
 }
@@ -89,30 +92,10 @@ extension PlaceDetailView {
     }
     
     private var photos: some View {
-        HStack(alignment: .center, spacing: 8.adjustedWidth) {
-            KFImage(URL(string: viewModel.placeDetail.imageUrlStrings[0]))
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .customSkeleton(with: viewModel.isPlaceDetailLoading)
-                .frame(width: 218.adjustedWidth, height: 168.adjustedHeight)
-                .cornerRadius(10, corners: .allCorners)
-            
-            VStack(alignment: .center, spacing: 8.adjustedHeight) {
-                KFImage(URL(string: viewModel.placeDetail.imageUrlStrings[1]))
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .customSkeleton(with: viewModel.isPlaceDetailLoading)
-                    .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
-                    .cornerRadius(10, corners: .allCorners)
-                
-                KFImage(URL(string: viewModel.placeDetail.imageUrlStrings[2]))
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .customSkeleton(with: viewModel.isPlaceDetailLoading)
-                    .frame(width: 110.adjustedWidth, height: 80.adjustedHeight)
-                    .cornerRadius(10, corners: .allCorners)
-            }
-        }
+        ThreeDividedPhoto(
+            imageUrlStrings: viewModel.placeDetail.imageUrlStrings,
+            isLoading: viewModel.isPlaceDetailLoading
+        )
     }
     
     private var informations: some View {

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -28,7 +28,7 @@ final class MapSheetViewModel: ObservableObject {
     private let placeDetailService: PlaceDetailAPI
     private var fetchPlaceDetailTask: Task<Void, Never>?
     
-    private let initialLocation = CLLocationCoordinate2D(latitude: 37.5598, longitude: 126.9770)
+    private let initialLocation = CLLocationCoordinate2D(latitude: 37.28557, longitude: 127.00996)
     private let span = MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
     private let spanRate: Double = 0.45
     

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -23,7 +23,6 @@ final class MapSheetViewModel: ObservableObject {
     // TODO: - HomeAPI 수정되면 다시 빈배열로
     @Published var mapPlaces: [MapPlace] = MapPlace.mockData
     @Published var placeDetail: PlaceDetail = PlaceDetail.skeletonData
-    @Published var currentLocation: CLLocationCoordinate2D? = nil
     
     private let placeListService: PlaceListAPI
     private let placeDetailService: PlaceDetailAPI
@@ -131,10 +130,6 @@ private extension MapSheetViewModel {
         }
     }
     
-    func setCurrentLocation(_ coordinate: CLLocationCoordinate2D) {
-        currentLocation = coordinate
-    }
-    
     func setCameraPosition(coordinate: CLLocationCoordinate2D, spanRate: Double) {
         withAnimation(.easeInOut(duration: 0.8)) {
             let adjustedCenter = CLLocationCoordinate2D(
@@ -147,24 +142,13 @@ private extension MapSheetViewModel {
     }
     
     func fetchPlaceList() {
-        self.isPlaceDetailLoading = true
-        
         Task {
-            if let currentLocation {
-                await fetchPlaceList(
-                    request: PlaceListRequestDTO(
-                        x: currentLocation.longitude,
-                        y: currentLocation.latitude
-                    )
+            await fetchPlaceList(
+                request: PlaceListRequestDTO(
+                    x: initialLocation.longitude,
+                    y: initialLocation.latitude
                 )
-            } else {
-                await fetchPlaceList(
-                    request: PlaceListRequestDTO(
-                        x: initialLocation.longitude,
-                        y: initialLocation.latitude
-                    )
-                )
-            }
+            )
         }
     }
     
@@ -175,9 +159,8 @@ private extension MapSheetViewModel {
         fetchPlaceDetailTask?.cancel()
         fetchPlaceDetailTask = Task {
             // TODO: - 임시 placeId
-            await fetchPlaceDetail(placeId: 153)
+            await fetchPlaceDetail(placeId: mapPlace.placeId)
         }
-        setCurrentLocation(mapPlace.coordinate)
         
         selectMarker(mapPlace)
         setCameraPosition(coordinate: mapPlace.coordinate, spanRate: spanRate)

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -20,8 +20,7 @@ final class MapSheetViewModel: ObservableObject {
     @Published var cameraPosition: MapCameraPosition
     @Published var sheetState: SheetState = .list
     @Published var bottomSheetHeight: CGFloat = SheetState.defaultHeight
-    // TODO: - HomeAPI 수정되면 다시 빈배열로
-    @Published var mapPlaces: [MapPlace] = MapPlace.mockData
+    @Published var mapPlaces: [MapPlace] = []
     @Published var placeDetail: PlaceDetail = PlaceDetail.skeletonData
     
     private let placeListService: PlaceListAPI

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -28,9 +28,12 @@ final class MapSheetViewModel: ObservableObject {
     private let placeDetailService: PlaceDetailAPI
     private var fetchPlaceDetailTask: Task<Void, Never>?
     
-    private let initialLocation = CLLocationCoordinate2D(latitude: 37.28557, longitude: 127.00996)
-    private let span = MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
-    private let spanRate: Double = 0.45
+    private let initialLocation = CLLocationCoordinate2D(latitude: 37.28757, longitude: 127.01550)
+    private var currentLocation = CLLocationCoordinate2D(latitude: 37.28757, longitude: 127.01550)
+    private var defaultSpan = MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+    private let defaultSpanRate: Double = 0.45
+    private let zoomSpan = MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
+    private let zoomSpanRate: Double = 0.225
     
     var alertErrorMessage: String = ""
     
@@ -58,11 +61,11 @@ final class MapSheetViewModel: ObservableObject {
         self.placeDetailService = placeDetailService
         
         let adjustedCenter = CLLocationCoordinate2D(
-            latitude: initialLocation.latitude - (span.latitudeDelta * spanRate),
+            latitude: initialLocation.latitude - (defaultSpan.latitudeDelta * defaultSpanRate),
             longitude: initialLocation.longitude
         )
         
-        cameraPosition = .region(MKCoordinateRegion(center: adjustedCenter, span: span))
+        cameraPosition = .region(MKCoordinateRegion(center: adjustedCenter, span: defaultSpan))
     }
     
     // MARK: - Dispatch
@@ -71,9 +74,16 @@ final class MapSheetViewModel: ObservableObject {
         switch action {
         case .setCameraToUser:
             if bottomSheetHeight == SheetState.minimumHeight {
-                setCameraPosition(coordinate: initialLocation, spanRate: 0.0)
+                setCameraPosition(
+                    coordinate: initialLocation,
+                    zoom: false,
+                    center: true
+                )
             } else {
-                setCameraPosition(coordinate: initialLocation, spanRate: spanRate)
+                setCameraPosition(
+                    coordinate: initialLocation,
+                    zoom: false
+                )
             }
             
         case .showMap:
@@ -99,6 +109,10 @@ final class MapSheetViewModel: ObservableObject {
                 break
                 
             case .detail:
+                setCameraPosition(
+                    coordinate: currentLocation,
+                    zoom: false
+                )
                 cancelFetchPlaceDetailTask()
                 deSelectMarker()
                 placeDetail = PlaceDetail.skeletonData
@@ -130,14 +144,19 @@ private extension MapSheetViewModel {
         }
     }
     
-    func setCameraPosition(coordinate: CLLocationCoordinate2D, spanRate: Double) {
+    func setCameraPosition(coordinate: CLLocationCoordinate2D, zoom: Bool, center: Bool = false) {
         withAnimation(.easeInOut(duration: 0.8)) {
             let adjustedCenter = CLLocationCoordinate2D(
-                latitude: coordinate.latitude - (span.latitudeDelta * spanRate),
+                latitude: coordinate.latitude - (defaultSpan.latitudeDelta * (center ? 0.0 : zoom ? zoomSpanRate : defaultSpanRate)),
                 longitude: coordinate.longitude
             )
             
-            cameraPosition = .region(MKCoordinateRegion(center: adjustedCenter, span: span))
+            cameraPosition = .region(
+                MKCoordinateRegion(
+                    center: adjustedCenter,
+                    span: zoom ? zoomSpan : defaultSpan
+                )
+            )
         }
     }
     
@@ -154,6 +173,8 @@ private extension MapSheetViewModel {
     
     func fetchPlaceDetail(_ mapPlace: MapPlace) {
         self.isPlaceDetailLoading = true
+        self.currentLocation = mapPlace.coordinate
+        self.currentLocation = mapPlace.coordinate
         self.placeDetail = PlaceDetail.skeletonData
         
         fetchPlaceDetailTask?.cancel()
@@ -163,7 +184,10 @@ private extension MapSheetViewModel {
         }
         
         selectMarker(mapPlace)
-        setCameraPosition(coordinate: mapPlace.coordinate, spanRate: spanRate)
+        setCameraPosition(
+            coordinate: mapPlace.coordinate,
+            zoom: true
+        )
         sheetState = .detail
     }
     

--- a/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
+++ b/GG-iOS/GG-iOS/Presentation/MapSheet/ViewModel/MapSheetViewModel.swift
@@ -23,6 +23,7 @@ final class MapSheetViewModel: ObservableObject {
     // TODO: - HomeAPI 수정되면 다시 빈배열로
     @Published var mapPlaces: [MapPlace] = MapPlace.mockData
     @Published var placeDetail: PlaceDetail = PlaceDetail.skeletonData
+    @Published var currentLocation: CLLocationCoordinate2D? = nil
     
     private let placeListService: PlaceListAPI
     private let placeDetailService: PlaceDetailAPI
@@ -80,42 +81,18 @@ final class MapSheetViewModel: ObservableObject {
             bottomSheetHeight = SheetState.minimumHeight
             
         case .showList:
-            fetchPlaceDetailTask?.cancel()
-            fetchPlaceDetailTask = nil
-            
+            cancelFetchPlaceDetailTask()
             bottomSheetHeight = SheetState.defaultHeight
             
         case .selectMarker(let mapPlace):
-            self.isPlaceDetailLoading = true
-            self.placeDetail = PlaceDetail.skeletonData
-            
-            fetchPlaceDetailTask?.cancel()
-            fetchPlaceDetailTask = Task {
-                // TODO: - 임시 placeId
-                await fetchPlaceDetail(placeId: 153)
-            }
-            
-            selectMarker(mapPlace)
-            setCameraPosition(coordinate: mapPlace.coordinate, spanRate: spanRate)
-            sheetState = .detail
+            fetchPlaceDetail(mapPlace)
             
             withAnimation(.easeInOut(duration: 0.3)) {
                 bottomSheetHeight = SheetState.defaultHeight
             }
             
         case .selectPlace(let mapPlace):
-            self.isPlaceDetailLoading = true
-            self.placeDetail = PlaceDetail.skeletonData
-            
-            fetchPlaceDetailTask?.cancel()
-            fetchPlaceDetailTask = Task {
-                // TODO: - 임시 placeId
-                await fetchPlaceDetail(placeId: 153)
-            }
-            
-            selectMarker(mapPlace)
-            setCameraPosition(coordinate: mapPlace.coordinate, spanRate: spanRate)
-            sheetState = .detail
+            fetchPlaceDetail(mapPlace)
             
         case .switchSheetState(let sheetState):
             switch sheetState {
@@ -123,25 +100,14 @@ final class MapSheetViewModel: ObservableObject {
                 break
                 
             case .detail:
-                fetchPlaceDetailTask?.cancel()
-                fetchPlaceDetailTask = nil
-                
+                cancelFetchPlaceDetailTask()
                 deSelectMarker()
                 placeDetail = PlaceDetail.skeletonData
                 self.sheetState = .list
             }
             
         case .fetchPlaceList:
-            self.isPlaceDetailLoading = true
-            
-            Task {
-                await fetchPlaceList(
-                    request: PlaceListRequestDTO(
-                        x: initialLocation.longitude,
-                        y: initialLocation.latitude
-                    )
-                )
-            }
+            fetchPlaceList()
         }
     }
 }
@@ -165,7 +131,10 @@ private extension MapSheetViewModel {
         }
     }
     
-    /// 카메라 위치를 변경합니다.
+    func setCurrentLocation(_ coordinate: CLLocationCoordinate2D) {
+        currentLocation = coordinate
+    }
+    
     func setCameraPosition(coordinate: CLLocationCoordinate2D, spanRate: Double) {
         withAnimation(.easeInOut(duration: 0.8)) {
             let adjustedCenter = CLLocationCoordinate2D(
@@ -175,6 +144,49 @@ private extension MapSheetViewModel {
             
             cameraPosition = .region(MKCoordinateRegion(center: adjustedCenter, span: span))
         }
+    }
+    
+    func fetchPlaceList() {
+        self.isPlaceDetailLoading = true
+        
+        Task {
+            if let currentLocation {
+                await fetchPlaceList(
+                    request: PlaceListRequestDTO(
+                        x: currentLocation.longitude,
+                        y: currentLocation.latitude
+                    )
+                )
+            } else {
+                await fetchPlaceList(
+                    request: PlaceListRequestDTO(
+                        x: initialLocation.longitude,
+                        y: initialLocation.latitude
+                    )
+                )
+            }
+        }
+    }
+    
+    func fetchPlaceDetail(_ mapPlace: MapPlace) {
+        self.isPlaceDetailLoading = true
+        self.placeDetail = PlaceDetail.skeletonData
+        
+        fetchPlaceDetailTask?.cancel()
+        fetchPlaceDetailTask = Task {
+            // TODO: - 임시 placeId
+            await fetchPlaceDetail(placeId: 153)
+        }
+        setCurrentLocation(mapPlace.coordinate)
+        
+        selectMarker(mapPlace)
+        setCameraPosition(coordinate: mapPlace.coordinate, spanRate: spanRate)
+        sheetState = .detail
+    }
+    
+    func cancelFetchPlaceDetailTask() {
+        fetchPlaceDetailTask?.cancel()
+        fetchPlaceDetailTask = nil
     }
 }
 


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 챗봇 이어가기 API 연동
- 새 message 올 경우 자동 Scroll
- gif에는 안 나오지만, placeDetail -> chatView 데이터 주입도 구현

|    구현 내용    |   iPhone 13 mini   |
| :-------------: | :----------: |
| A 기능 | <img src = "https://github.com/user-attachments/assets/6fff0931-4763-42eb-801b-20677ae2a6b8" width ="250"> |

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #40 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 챗봇 대화 이어가기 추가 — 제안된 질문 선택으로 대화 지속 가능

* **개선 사항**
  * 채팅 화면 자동 스크롤 및 로딩 상태 표시 추가; 챗봇 로딩 중 액션 버튼 비활성화
  * 장소 사진을 최대 3장으로 채우는 3분할 레이아웃 도입(빈 슬롯은 플레이스홀더로 채움)
  * 이미지 로드 실패 시 대체 아이콘 표시
  * 장소 설명이 없을 경우 해당 섹션을 숨기도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->